### PR TITLE
Fix: Set $is_preview value globally

### DIFF
--- a/includes/core/helpers.php
+++ b/includes/core/helpers.php
@@ -16,6 +16,7 @@ function get_flexible($selector, $post_id = false){
     // Vars
     $field = acf_get_field($selector);
     $flexible = acf_get_field_type('flexible_content');
+    global $is_preview;
     $is_preview = false;
     
     // Actions

--- a/includes/fields/field-flexible-content.php
+++ b/includes/fields/field-flexible-content.php
@@ -846,6 +846,7 @@ function acfe_flexible_render_field($field){
         return;
     
     // Vars
+    global $is_preview;
     $is_preview = true;
     
     // Actions


### PR DESCRIPTION
Hey, 
first of all: thanks for the amazing plugin! :)

While trying to disable frontend enqueuing for individual CSS files of each flexible layout (we want to serve one CSS for all our components), I was trying do distinguish backend and frontend with `$is_preview` when using the filter `acfe/flexible/render/style` and recognized it was always `NULL`. I figured this was due to `$is_preview` not being saved to the global variable in `acfe_flexible_render_field()` and `get_flexible()`. 

At least those changes made it work for me. Can you confirm this?

Thanks!
Moritz