### PR TITLE
Changing lifecycle hook for load function to „after_setup_theme“

### DIFF
--- a/acf-extended.php
+++ b/acf-extended.php
@@ -68,7 +68,7 @@ class ACFE{
         include_once(ACFE_PATH . 'init.php');
         
         // Load
-        add_action('plugins_loaded', array($this, 'load'));
+        add_action('after_setup_theme', array($this, 'load'));
         
     }
     


### PR DESCRIPTION
This allows for ACF Pro versions that are bundled with the theme to be loaded before the acf extended load function is called.

This solves the problem that ACF-Extended did not load with bundled ACF-Pro Versions. I have tested this with my custom setup where I bundled ACF-Pro with a theme. I have not conducted broader tests on other functionalities...