### PR TITLE
Translatability overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/acf-extended.php
+++ b/acf-extended.php
@@ -6,6 +6,7 @@
  * Author:      ACF Extended
  * Author URI:  https://www.acf-extended.com
  * Text Domain: acfe
+ * Domain Path: /languages
  */
 
 if(!defined('ABSPATH'))
@@ -272,5 +273,11 @@ function acfe(){
 
 // Instantiate.
 acfe();
+
+function acfe_load_plugin_textdomain() {
+    load_plugin_textdomain( 'acfe', FALSE, basename( dirname( __FILE__ ) ) . '/languages/' );
+}
+add_action( 'plugins_loaded', 'acfe_load_plugin_textdomain' );
+
 
 endif;

--- a/includes/admin/options.class.php
+++ b/includes/admin/options.class.php
@@ -176,8 +176,8 @@ class ACFE_Admin_Options_List extends WP_List_Table{
 		$title = '<strong>' . $item['option_name'] . '</strong>';
 
 		$actions = array(
-			'edit' => sprintf('<a href="?page=%s&action=edit&option=%s">' . __('Edit') . '</a>', esc_attr($_REQUEST['page']), absint($item['option_id'])),
-			'delete' => sprintf('<a href="?page=%s&action=delete&option=%s&_wpnonce=%s">' . __('Delete') . '</a>', esc_attr($_REQUEST['page']), absint($item['option_id']), $delete_nonce),
+			'edit' => sprintf('<a href="?page=%s&action=edit&option=%s">' . __('Edit', 'acfe') . '</a>', esc_attr($_REQUEST['page']), absint($item['option_id'])),
+			'delete' => sprintf('<a href="?page=%s&action=delete&option=%s&_wpnonce=%s">' . __('Delete', 'acfe') . '</a>', esc_attr($_REQUEST['page']), absint($item['option_id']), $delete_nonce),
 		);
 
 		return $title . $this->row_actions($actions);

--- a/includes/admin/options.php
+++ b/includes/admin/options.php
@@ -22,8 +22,8 @@ function acfe_options_menu(){
     
     $hook = add_submenu_page(
         'options-general.php', 
-        __('Options'), 
-        __('Options'), 
+        __('Options', 'acfe'), 
+        __('Options', 'acfe'), 
         acf_get_setting('capability'), 
         'acfe-options'
     );
@@ -158,7 +158,7 @@ function acfe_options_load_delete(){
 add_action('acfe/options/load/message=deleted', 'acfe_options_load_delete_message');
 function acfe_options_load_delete_message(){
     
-    acf_add_admin_notice(__('Option has been deleted'), 'success');
+    acf_add_admin_notice(__('Option has been deleted', 'acfe'), 'success');
     
 }
 
@@ -194,7 +194,7 @@ function acfe_options_load_bulk_delete(){
 add_action('acfe/options/load/message=bulk-deleted', 'acfe_options_load_bulk_delete_message');
 function acfe_options_load_bulk_delete_message(){
     
-    acf_add_admin_notice(__('Options have been deleted'), 'success');
+    acf_add_admin_notice(__('Options have been deleted', 'acfe'), 'success');
     
 }
 
@@ -305,7 +305,7 @@ function acfe_options_edit_metabox(){
     $fields = array();
     
     $fields[] = array(
-        'label'             => __('Name'),
+        'label'             => __('Name', 'acfe'),
         'key'               => 'field_acfe_options_edit_name',
         'name'              => 'field_acfe_options_edit_name',
         'type'              => 'text',
@@ -330,7 +330,7 @@ function acfe_options_edit_metabox(){
     if(is_serialized($option['option_value']) || $option['option_value'] != strip_tags($option['option_value'])){
         
         $type = 'serilized';
-        $instructions = 'Use this <a href="https://duzun.me/playground/serialize" target="_blank">online tool</a> to unserialize/seriliaze data.';
+        $instructions = __('Use this <a href="https://duzun.me/playground/serialize" target="_blank">online tool</a> to unserialize/seriliaze data.', 'acfe');
         
         if($option['option_value'] != strip_tags($option['option_value'])){
             
@@ -340,7 +340,7 @@ function acfe_options_edit_metabox(){
         }
         
         $fields[] = array(
-            'label'             => __('Value <code style="font-size:11px;float:right; line-height:1.2; margin-top:1px;">' . $type . '</code>'),
+            'label'             => __('Value <code style="font-size:11px;float:right; line-height:1.2; margin-top:1px;">' . $type . '</code>', 'acfe'),
             'key'               => 'field_acfe_options_edit_value',
             'name'              => 'field_acfe_options_edit_value',
             'type'              => 'textarea',
@@ -368,10 +368,10 @@ function acfe_options_edit_metabox(){
     elseif(acfe_is_json($option['option_value'])){
         
         $type = 'json';
-        $instructions = 'Use this <a href="http://solutions.weblite.ca/php2json/" target="_blank">online tool</a> to decode/encode json.';
+        $instructions = __('Use this <a href="http://solutions.weblite.ca/php2json/" target="_blank">online tool</a> to decode/encode json.', 'acfe');
         
         $fields[] = array(
-            'label'             => __('Value <code style="font-size:11px;float:right; line-height:1.2; margin-top:1px;">' . $type . '</code>'),
+            'label'             => __('Value', 'acfe') . ' <code style="font-size:11px;float:right; line-height:1.2; margin-top:1px;">' . $type . '</code>',
             'key'               => 'field_acfe_options_edit_value',
             'name'              => 'field_acfe_options_edit_value',
             'type'              => 'textarea',
@@ -400,10 +400,10 @@ function acfe_options_edit_metabox(){
         
         $type = '';
         if(!empty($option['option_value']))
-            $type = '<code style="font-size:11px;float:right; line-height:1.2; margin-top:1px;">string</code>';
+            $type = __('<code style="font-size:11px;float:right; line-height:1.2; margin-top:1px;">string</code>', 'acfe');
         
         $fields[] = array(
-            'label'             => __('Value ' . $type),
+            'label'             => __('Value ', 'acfe') . $type,
             'key'               => 'field_acfe_options_edit_value',
             'name'              => 'field_acfe_options_edit_value',
             'type'              => 'text',
@@ -427,7 +427,7 @@ function acfe_options_edit_metabox(){
     }
     
     $fields[] = array(
-        'label'             => __('Autoload'),
+        'label'             => __('Autoload', 'acfe'),
         'key'               => 'field_acfe_options_edit_autoload',
         'name'              => 'field_acfe_options_edit_autoload',
         'type'              => 'select',
@@ -442,8 +442,8 @@ function acfe_options_edit_metabox(){
         'maxlength'         => '',
         'value'             => $option['autoload'],
         'choices'           => array(
-            'no'    => __('No'),
-            'yes'   => __('Yes'),
+            'no'    => __('No', 'acfe'),
+            'yes'   => __('Yes', 'acfe'),
         ),
         'wrapper'           => array(
             'width' => '',
@@ -454,13 +454,13 @@ function acfe_options_edit_metabox(){
     
     $field_group['fields'] = $fields;
     
-    $metabox_submit_title = __('Submit','acf');
-    $metabox_main_title = __('Add Option');
+    $metabox_submit_title = __('Submit', 'acfe');
+    $metabox_main_title = __('Add Option', 'acfe');
     
     if(!empty($option['option_id'])){
         
-        $metabox_submit_title = __('Edit','acf');
-        $metabox_main_title = __('Edit Option');
+        $metabox_submit_title = __('Edit', 'acfe');
+        $metabox_main_title = __('Edit Option', 'acfe');
         
     }
     
@@ -475,7 +475,7 @@ function acfe_options_edit_metabox(){
             <?php if(!empty($option['option_id'])){ ?>
             
                 <div id="delete-action">
-                    <a class="submitdelete deletion" style="color:#a00;" href="<?php echo sprintf('?page=%s&action=%s&option=%s&_wpnonce=%s', esc_attr($_REQUEST['page']), 'delete', $option['option_id'], $delete_nonce); ?>"><?php _e('Delete'); ?></a>
+                    <a class="submitdelete deletion" style="color:#a00;" href="<?php echo sprintf('?page=%s&action=%s&option=%s&_wpnonce=%s', esc_attr($_REQUEST['page']), 'delete', $option['option_id'], $delete_nonce); ?>"><?php _e('Delete', 'acfe'); ?></a>
                 </div>
                 
             <?php } ?>
@@ -505,7 +505,7 @@ function acfe_options_edit_metabox(){
             'style'			=> $field_group['style'],
             'label'			=> $field_group['label_placement'],
             'editLink'		=> '',
-            'editTitle'		=> __('Edit field group', 'acf'),
+            'editTitle'		=> __('Edit field group', 'acfe'),
             'visibility'	=> true
         );
         
@@ -563,7 +563,7 @@ function acfe_options_edit_save_post($post_id){
 add_action('acfe/options/load/message=updated', 'acfe_options_load_edit_message');
 function acfe_options_load_edit_message(){
     
-    acf_add_admin_notice(__('Option has been updated'), 'success');
+    acf_add_admin_notice(__('Option has been updated', 'acfe'), 'success');
     
 }
 
@@ -574,6 +574,6 @@ function acfe_options_load_edit_message(){
 add_action('acfe/options/load/message=added', 'acfe_options_load_add_message');
 function acfe_options_load_add_message(){
     
-    acf_add_admin_notice(__('Option has been added'), 'success');
+    acf_add_admin_notice(__('Option has been added', 'acfe'), 'success');
     
 }

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -9,7 +9,7 @@ if(!defined('ABSPATH'))
 add_filter('install_plugins_tabs', 'acfe_admin_plugins_tabs');
 function acfe_admin_plugins_tabs($tabs){
     
-    $tabs['acf'] = __('Advanced Custom Fields');
+    $tabs['acf'] = __('Advanced Custom Fields', 'acfe');
     
     return $tabs;
     

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -9,7 +9,7 @@ function acfe_admin_settings_menu(){
     if(!acf_get_setting('show_admin'))
         return;
     
-    $submenu_page = add_submenu_page('edit.php?post_type=acf-field-group', __('Settings'), __('Settings'), acf_get_setting('capability'), 'acfe-settings', 'acfe_admin_settings_html');
+    $submenu_page = add_submenu_page('edit.php?post_type=acf-field-group', __('Settings', 'acfe'), __('Settings', 'acfe'), acf_get_setting('capability'), 'acfe-settings', 'acfe_admin_settings_html');
     
     add_action('admin_print_scripts-' . $submenu_page, function(){
         acf_enqueue_scripts();
@@ -21,12 +21,12 @@ function acfe_admin_settings_html(){
 ?>
 <div class="wrap" id="acfe-admin-settings">
     
-    <h1><?php _e('Settings'); ?></h1>
+    <h1><?php _e('Settings', 'acfe'); ?></h1>
     
     <div id="poststuff">
         
         <div class="postbox acf-postbox">
-            <h2 class="hndle ui-sortable-handle"><span><?php _e('Settings'); ?></span></h2>
+            <h2 class="hndle ui-sortable-handle"><span><?php _e('Settings', 'acfe'); ?></span></h2>
             <div class="inside acf-fields -left">
             
                 <?php 
@@ -47,171 +47,171 @@ function acfe_admin_settings_html(){
                 $settings = array(
                     array(
                         'name'  => 'path',
-                        'label' => 'Path',
+                        'label' => __('Path', 'acfe'),
                         'value' => '<code>' . acf_get_setting('path') . '</code>',
-                        'description' => 'Absolute path to ACF plugin folder including trailing slash.<br />Defaults to plugin_dir_path'
+                        'description' => __('Absolute path to ACF plugin folder including trailing slash.<br />Defaults to plugin_dir_path', 'acfe')
                     ),
                     array(
                         'name'  => 'dir',
-                        'label' => 'Directory',
+                        'label' => __('Directory', 'acfe'),
                         'value' => '<code>' . acf_get_setting('dir') . '</code>',
-                        'description' => 'URL to ACF plugin folder including trailing slash. Defaults to plugin_dir_url'
+                        'description' => __('URL to ACF plugin folder including trailing slash. Defaults to plugin_dir_url', 'acfe')
                     ),
                     array(
                         'name'  => 'show_admin',
-                        'label' => 'Show menu',
+                        'label' => __('Show menu',
                         'value' => '<code>' . (acf_get_setting('show_admin') ? __('True'): __('False')) . '</code>',
-                        'description' => 'Show/hide ACF menu item. Defaults to true'
+                        'description' => __('Show/hide ACF menu item. Defaults to true'
                     ),
                     array(
                         'name'  => 'stripslashes',
-                        'label' => 'Strip slashes',
+                        'label' => __('Strip slashes, 'acfe')',
                         'value' => '<code>' . (acf_get_setting('stripslashes') ? __('True'): __('False')) . '</code>',
-                        'description' => 'Runs the function stripslashes on all $_POST data. Some servers / WP instals may require this extra functioanlity. Defaults to false'
+                        'description' => __('Runs the function stripslashes on all $_POST data. Some servers / WP instals may require this extra functioanlity. Defaults to false', 'acfe')
                     ),
                     array(
                         'name'  => 'local',
-                        'label' => 'PHP/Json',
+                        'label' => __('PHP/Json', 'acfe'),
                         'value' => '<code>' . (acf_get_setting('local') ? __('True'): __('False')) . '</code>',
-                        'description' => 'Enable/Disable local (PHP/json) fields. Defaults to true'
+                        'description' => __('Enable/Disable local (PHP/json) fields. Defaults to true', 'acfe')
                     ),
                     array(
                         'name'  => 'json',
-                        'label' => 'Json',
-                        'value' => '<code>' . (acf_get_setting('json') ? __('True'): __('False')) . '</code>',
-                        'description' => 'Enable/Disable json fields. Defaults to true'
+                        'label' => __('Json', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('json') ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Enable/Disable json fields. Defaults to true', 'acfe')
                     ),
                     array(
                         'name'  => 'save_json',
-                        'label' => 'Json folder (save)',
+                        'label' => __('Json folder (save)', 'acfe'),
                         'value' => '<code>' . acf_get_setting('save_json') . '</code>',
-                        'description' => 'Absolute path to folder where json files will be created when field groups are saved.<br />Defaults to ‘acf-json’ folder within current theme'
+                        'description' => __('Absolute path to folder where json files will be created when field groups are saved.<br />Defaults to ‘acf-json’ folder within current theme', 'acfe')
                     ),
                     array(
                         'name'  => 'load_json',
-                        'label' => 'Json folder (load)',
+                        'label' => __('Json folder (load)', 'acfe'),
                         'value' => '<code>' . $load_json_text . '</code>',
-                        'description' => 'Array of absolutes paths to folders where field group json files can be read.<br />Defaults to an array containing at index 0, the ‘acf-json’ folder within current theme'
+                        'description' => __('Array of absolutes paths to folders where field group json files can be read.<br />Defaults to an array containing at index 0, the ‘acf-json’ folder within current theme', 'acfe')
                     ),
                     array(
                         'name'  => 'default_language',
-                        'label' => 'Default language',
+                        'label' => __('Default language', 'acfe'),
                         'value' => '<code>' . acf_get_setting('default_language') . '</code>',
-                        'description' => 'Language code of the default language. Defaults to ”.<br />If WPML is active, ACF will default this to the WPML default language setting'
+                        'description' => __('Language code of the default language. Defaults to ”.<br />If WPML is active, ACF will default this to the WPML default language setting', 'acfe')
                     ),
                     array(
                         'name'  => 'current_language',
-                        'label' => 'Current language',
+                        'label' => __('Current language', 'acfe'),
                         'value' => '<code>' . acf_get_setting('current_language') . '</code>',
-                        'description' => 'Language code of the current post’s language. Defaults to ”.<br />If WPML is active, ACF will default this to the WPML current language'
+                        'description' => __('Language code of the current post’s language. Defaults to ”.<br />If WPML is active, ACF will default this to the WPML current language', 'acfe')
                     ),
                     array(
                         'name'  => 'capability',
-                        'label' => 'Capability',
+                        'label' => __('Capability', 'acfe'),
                         'value' => '<code>' . acf_get_setting('capability') . '</code>',
-                        'description' => 'Capability used for ACF post types and if the current user can see the ACF menu item.<br />Defaults to ‘manage_options’.'
+                        'description' => __('Capability used for ACF post types and if the current user can see the ACF menu item.<br />Defaults to ‘manage_options’.', 'acfe')
                     ),
                     array(
                         'name'  => 'show_updates',
-                        'label' => 'Show updates',
-                        'value' => '<code>' . (acf_get_setting('show_updates') ? __('True'): __('False')) . '</code>',
-                        'description' => 'Enable/Disable updates to appear in plugin list and show/hide the ACF updates admin page.<br />Defaults to true.'
+                        'label' => __('Show updates', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('show_updates') ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Enable/Disable updates to appear in plugin list and show/hide the ACF updates admin page.<br />Defaults to true.', 'acfe')
                     ),
                     array(
                         'name'  => 'export_textdomain',
-                        'label' => 'Export textdomain',
+                        'label' => __('Export textdomain', 'acfe'),
                         'value' => '<code>' . (acf_get_setting('export_textdomain') ? __('True'): __('False')) . '</code>',
-                        'description' => 'Array of keys used during the ‘Export to PHP’ feature to wrap strings within the __() function.<br />Defaults to array(’title’, ’label’, ’instructions’). Depreciated in v5.3.4 – please see l10n_field and l10n_field_group'
+                        'description' => __('Array of keys used during the ‘Export to PHP’ feature to wrap strings within the __() function.<br />Defaults to array(’title’, ’label’, ’instructions’). Depreciated in v5.3.4 – please see l10n_field and l10n_field_group', 'acfe')
                     ),
                     array(
                         'name'  => 'export_translate',
-                        'label' => 'Export translate',
+                        'label' => __('Export translate', 'acfe'),
                         'value' => '<code>' . print_r(acf_get_setting('export_translate'), true) . '</code>',
-                        'description' => 'Used during the ‘Export to PHP’ feature to wrap strings within the __() function.<br />Depreciated in v5.4.4 – please see l10n_textdomain'
+                        'description' => __('Used during the ‘Export to PHP’ feature to wrap strings within the __() function.<br />Depreciated in v5.4.4 – please see l10n_textdomain'
                     ),
                     array(
                         'name'  => 'autoload',
-                        'label' => 'Auto load',
-                        'value' => '<code>' . (acf_get_setting('autoload') ? __('True'): __('False')) . '</code>',
-                        'description' => 'Sets the text domain used when translating field and field group settings.<br />Defaults to ”. Strings will not be translated if this setting is empty'
+                        'label' => __('Auto load', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('autoload') ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Sets the text domain used when translating field and field group settings.<br />Defaults to ”. Strings will not be translated if this setting is empty', 'acfe')
                     ),
                     array(
                         'name'  => 'l10n',
-                        'label' => 'l10n',
-                        'value' => '<code>' . (acf_get_setting('l10n') ? __('True'): __('False')) . '</code>',
-                        'description' => 'Allows ACF to translate field and field group settings using the __() function.<br />Defaults to true. Useful to override translation without modifying the textdomain'
+                        'label' => __('l10n', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('l10n') ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Allows ACF to translate field and field group settings using the __() function.<br />Defaults to true. Useful to override translation without modifying the textdomain', 'acfe')
                     ),
                     array(
                         'name'  => 'l10n_textdomain',
-                        'label' => 'l10n Textdomain',
-                        'value' => '<code>' . (acf_get_setting('l10n') ? __('True'): __('False')) . '</code>',
-                        'description' => 'Sets the text domain used when translating field and field group settings.<br />Defaults to ”. Strings will not be translated if this setting is empty'
+                        'label' => __('l10n Textdomain', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('l10n') ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Sets the text domain used when translating field and field group settings.<br />Defaults to ”. Strings will not be translated if this setting is empty', 'acfe')
                     ),
                     array(
                         'name'  => 'l10n_field',
-                        'label' => 'l10n Field',
+                        'label' => __('l10n Field', 'acfe'),
                         'value' => '<code>' . print_r(acf_get_setting('l10n_field'), true) . '</code>',
-                        'description' => 'An array of settings to translate when loading and exporting a field.<br />Defaults to array(’label’, ’instructions’). Depreciated in v5.3.6 – please see acf/translate_field filter'
+                        'description' => __('An array of settings to translate when loading and exporting a field.<br />Defaults to array(’label’, ’instructions’). Depreciated in v5.3.6 – please see acf/translate_field filter', 'acfe')
                     ),
                     array(
                         'name'  => 'l10n_field_group',
-                        'label' => 'l10n Field group',
+                        'label' => __('l10n Field group', 'acfe'),
                         'value' => '<code>' . print_r(acf_get_setting('l10n_field_group'), true) . '</code>',
-                        'description' => 'An array of settings to translate when loading and exporting a field group.<br />Defaults to array(’title’). Depreciated in v5.3.6 – please see acf/translate_field_group filter'
+                        'description' => __('An array of settings to translate when loading and exporting a field group.<br />Defaults to array(’title’). Depreciated in v5.3.6 – please see acf/translate_field_group filter', 'acfe')
                     ),
                     array(
                         'name'  => 'google_api_key',
-                        'label' => 'Google API Key',
+                        'label' => __('Google API Key', 'acfe'),
                         'value' => '<code>' . acf_get_setting('google_api_key') . '</code>',
-                        'description' => 'Specify a Google Maps API authentication key to prevent usage limits.<br />Defaults to ”'
+                        'description' => __('Specify a Google Maps API authentication key to prevent usage limits.<br />Defaults to ”', 'acfe')
                     ),
                     array(
                         'name'  => 'google_api_client',
-                        'label' => 'Google API Key',
+                        'label' => __('Google API Key', 'acfe'),
                         'value' => '<code>' . acf_get_setting('google_api_client') . '</code>',
-                        'description' => 'Specify a Google Maps API Client ID to prevent usage limits.<br />Not needed if using google_api_key. Defaults to ”'
+                        'description' => __('Specify a Google Maps API Client ID to prevent usage limits.<br />Not needed if using google_api_key. Defaults to ”', 'acfe')
                     ),
                     array(
                         'name'  => 'enqueue_google_maps',
-                        'label' => 'Enqueue Google Maps',
-                        'value' => '<code>' . (acf_get_setting('enqueue_google_maps') ? __('True'): __('False')) . '</code>',
-                        'description' => 'Allows ACF to enqueue and load the Google Maps API JS library.<br />Defaults to true'
+                        'label' => __('Enqueue Google Maps', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('enqueue_google_maps') ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Allows ACF to enqueue and load the Google Maps API JS library.<br />Defaults to true', 'acfe')
                     ),
                     array(
                         'name'  => 'enqueue_select2',
-                        'label' => 'Enqueue Select2',
-                        'value' => '<code>' . (acf_get_setting('enqueue_select2') ? __('True'): __('False')) . '</code>',
-                        'description' => 'Allows ACF to enqueue and load the Select2 JS/CSS library.<br />Defaults to true'
+                        'label' => __('Enqueue Select2', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('enqueue_select2') ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Allows ACF to enqueue and load the Select2 JS/CSS library.<br />Defaults to true', 'acfe')
                     ),
                     array(
                         'name'  => 'select2_version',
-                        'label' => 'Select2 version',
+                        'label' => __('Select2 version', 'acfe'),
                         'value' => '<code>' . acf_get_setting('select2_version') . '</code>',
-                        'description' => 'Defines which version of Select2 library to enqueue. Either 3 or 4.<br />Defaults to 4 since ACF 5.6.0'
+                        'description' => __('Defines which version of Select2 library to enqueue. Either 3 or 4.<br />Defaults to 4 since ACF 5.6.0'
                     ),
                     array(
                         'name'  => 'enqueue_datepicker',
-                        'label' => 'Enqueue Datepicker',
-                        'value' => '<code>' . (acf_get_setting('enqueue_datepicker') ? __('True'): __('False')) . '</code>',
-                        'description' => 'Allows ACF to enqueue and load the WP datepicker JS/CSS library.<br />Defaults to true'
+                        'label' => __('Enqueue Datepicker', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('enqueue_datepicker') ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Allows ACF to enqueue and load the WP datepicker JS/CSS library.<br />Defaults to true', 'acfe')
                     ),
                     array(
                         'name'  => 'enqueue_datetimepicker',
-                        'label' => 'Enqueue Date/timepicker',
-                        'value' => '<code>' . (acf_get_setting('enqueue_datetimepicker') ? __('True'): __('False')) . '</code>',
-                        'description' => 'Allows ACF to enqueue and load the datetimepicker JS/CSS library.<br />Defaults to true'
+                        'label' => __('Enqueue Date/timepicker', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('enqueue_datetimepicker') ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Allows ACF to enqueue and load the datetimepicker JS/CSS library.<br />Defaults to true', 'acfe')
                     ),
                     array(
                         'name'  => 'row_index_offset',
-                        'label' => 'Row index offset',
+                        'label' => __('Row index offset', 'acfe'),
                         'value' => '<code>' . acf_get_setting('row_index_offset') . '</code>',
-                        'description' => 'Defines the starting index used in all ‘loop’ and ‘row’ functions.<br />Defaults to 1 (1 is the first row), can be changed to 0 (0 is the first row)'
+                        'description' => __('Defines the starting index used in all ‘loop’ and ‘row’ functions.<br />Defaults to 1 (1 is the first row), can be changed to 0 (0 is the first row)', 'acfe')
                     ),
                     array(
                         'name'  => 'remove_wp_meta_box',
-                        'label' => 'Remove WP meta box',
-                        'value' => '<code>' . (acf_get_setting('remove_wp_meta_box') ? __('True'): __('False')) . '</code>',
-                        'description' => 'Allows ACF to remove the default WP custom fields metabox. Defaults to true'
+                        'label' => __('Remove WP meta box', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('remove_wp_meta_box') ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Allows ACF to remove the default WP custom fields metabox. Defaults to true', 'acfe')
                     ),
                 );
                 
@@ -232,7 +232,7 @@ function acfe_admin_settings_html(){
                 <?php 
                 acf_render_field_wrap(array(
                     'type'  => 'tab',
-                    'label' => 'ACF: Extended',
+                    'label' => __('ACF: Extended', 'acfe'),
                 ));
                 ?>
                 
@@ -247,123 +247,123 @@ function acfe_admin_settings_html(){
                 $settings = array(
                     array(
                         'name'  => 'acfe/modules/author',
-                        'label' => 'Module: Author',
-                        'value' => '<code>' . (acf_get_setting('acfe/modules/author', true) ? __('True'): __('False')) . '</code>',
-                        'description' => 'Show/hide the Author module. Defaults to true'
+                        'label' => __('Module: Author', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('acfe/modules/author', true) ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Show/hide the Author module. Defaults to true', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/modules/dynamic_block_types',
-                        'label' => 'Module: Dynamic Block Types',
-                        'value' => '<code>' . (acf_get_setting('acfe/modules/dynamic_block_types', true) ? __('True'): __('False')) . '</code>',
-                        'description' => 'Show/hide the Block Types module. Defaults to true'
+                        'label' => __('Module: Dynamic Block Types', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('acfe/modules/dynamic_block_types', true) ? __('True'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Show/hide the Block Types module. Defaults to true', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/modules/dynamic_forms',
-                        'label' => 'Module: Dynamic Forms',
-                        'value' => '<code>' . (acf_get_setting('acfe/modules/dynamic_forms', true) ? __('True'): __('False')) . '</code>',
-                        'description' => 'Show/hide the Forms module. Defaults to true'
+                        'label' => __('Module: Dynamic Forms', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('acfe/modules/dynamic_forms', true) ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Show/hide the Forms module. Defaults to true', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/modules/dynamic_post_types',
-                        'label' => 'Module: Dynamic Post Types',
-                        'value' => '<code>' . (acf_get_setting('acfe/modules/dynamic_post_types', true) ? __('True'): __('False')) . '</code>',
-                        'description' => 'Show/hide the Post Types module. Defaults to true'
+                        'label' => __('Module: Dynamic Post Types', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('acfe/modules/dynamic_post_types', true) ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Show/hide the Post Types module. Defaults to true', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/modules/dynamic_taxonomies',
-                        'label' => 'Module: Dynamic Taxonomies',
-                        'value' => '<code>' . (acf_get_setting('acfe/modules/dynamic_taxonomies', true) ? __('True'): __('False')) . '</code>',
-                        'description' => 'Show/hide the Taxonomies module. Defaults to true'
+                        'label' => __('Module: Dynamic Taxonomies', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('acfe/modules/dynamic_taxonomies', true) ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Show/hide the Taxonomies module. Defaults to true', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/modules/dynamic_options_pages',
-                        'label' => 'Module: Dynamic Options Pages',
-                        'value' => '<code>' . (acf_get_setting('acfe/modules/dynamic_options_pages', true) ? __('True'): __('False')) . '</code>',
-                        'description' => 'Show/hide the Options Pages module. Defaults to true'
+                        'label' => __('Module: Dynamic Options Pages', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('acfe/modules/dynamic_options_pages', true) ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Show/hide the Options Pages module. Defaults to true', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/modules/options',
-                        'label' => 'Module: Options',
-                        'value' => '<code>' . (acf_get_setting('acfe/modules/options', true) ? __('True'): __('False')) . '</code>',
-                        'description' => 'Show/hide the Options module. Defaults to true'
+                        'label' => __('Module: Options', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('acfe/modules/options', true) ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Show/hide the Options module. Defaults to true', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/modules/taxonomies',
-                        'label' => 'Module: Taxonomies Enhancements',
-                        'value' => '<code>' . (acf_get_setting('acfe/modules/taxonomies', true) ? __('True'): __('False')) . '</code>',
-                        'description' => 'Show/hide the Taxonomies enhancements module. Defaults to true'
+                        'label' => __('Module: Taxonomies Enhancements', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('acfe/modules/taxonomies', true) ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Show/hide the Taxonomies enhancements module. Defaults to true', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/field/recaptcha/site_key',
-                        'label' => 'Field: reCaptcha site key',
+                        'label' => __('Field: reCaptcha site key', 'acfe'),
                         'value' => '<code>' . acf_get_setting('acfe/field/recaptcha/site_key') . '</code>',
-                        'description' => 'The default reCaptcha site key'
+                        'description' => __('The default reCaptcha site key', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/field/recaptcha/secret_key',
-                        'label' => 'Field: reCaptcha secret key',
+                        'label' => __('Field: reCaptcha secret key', 'acfe'),
                         'value' => '<code>' . acf_get_setting('acfe/field/recaptcha/secret_key') . '</code>',
-                        'description' => 'The default reCaptcha secret key'
+                        'description' => __('The default reCaptcha secret key', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/field/recaptcha/version',
-                        'label' => 'Field: reCaptcha version',
+                        'label' => __('Field: reCaptcha version', 'acfe'),
                         'value' => '<code>' . acf_get_setting('acfe/field/recaptcha/version', 'v2') . '</code>',
-                        'description' => 'The default reCaptcha version'
+                        'description' => __('The default reCaptcha version', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/field/recaptcha/v2/theme',
-                        'label' => 'Field: reCaptcha v2 theme',
+                        'label' => __('Field: reCaptcha v2 theme', 'acfe'),
                         'value' => '<code>' . acf_get_setting('acfe/field/recaptcha/v2/theme', 'light') . '</code>',
-                        'description' => 'The default reCaptcha v2 theme'
+                        'description' => __('The default reCaptcha v2 theme', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/field/recaptcha/v2/size',
-                        'label' => 'Field: reCaptcha v2 size',
+                        'label' => __('Field: reCaptcha v2 size', 'acfe'),
                         'value' => '<code>' . acf_get_setting('acfe/field/recaptcha/v2/size', 'normal') . '</code>',
-                        'description' => 'The default reCaptcha v2 size'
+                        'description' => __('The default reCaptcha v2 size', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/field/recaptcha/v3/hide_logo',
-                        'label' => 'Field: reCaptcha v3 hide logo',
+                        'label' => __('Field: reCaptcha v3 hide logo', 'acfe'),
                         'value' => '<code>' . acf_get_setting('acfe/field/recaptcha/v3/hide_logo') . '</code>',
-                        'description' => 'Show/hide reCaptcha v3 logo'
+                        'description' => __('Show/hide reCaptcha v3 logo', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/dev',
-                        'label' => 'Dev mode',
-                        'value' => '<code>' . (acf_get_setting('acfe/dev') ? __('True'): __('False')) . '</code>',
-                        'description' => 'Show/hide the advanced WP post meta box. Defaults to false'
+                        'label' => __('Dev mode', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('acfe/dev') ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Show/hide the advanced WP post meta box. Defaults to false', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/php',
-                        'label' => 'PHP',
-                        'value' => '<code>' . (acf_get_setting('acfe/php') ? __('True'): __('False')) . '</code>',
-                        'description' => 'Allow PHP Sync'
+                        'label' => __('PHP', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('acfe/php') ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Allow PHP Sync', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/php_found',
-                        'label' => 'PHP: Found',
+                        'label' => __('PHP: Found', 'acfe'),
                         'value' => '<code>' . (acf_get_setting('acfe/php_found') ? __('True'): __('False')) . '</code>',
-                        'description' => 'Found PHP Sync load folder'
+                        'description' => __('Found PHP Sync load folder', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/php_save',
-                        'label' => 'PHP: Save',
+                        'label' => __('PHP: Save', 'acfe'),
                         'value' => '<code>' . acf_get_setting('acfe/php_save') . '</code>',
-                        'description' => 'Found PHP Sync save folder'
+                        'description' => 'Found PHP Sync save folder', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/php_load',
-                        'label' => 'PHP: Load',
+                        'label' => __('PHP: Load', 'acfe'),
                         'value' => '<code>' . $load_php_text . '</code>',
-                        'description' => 'PHP Sync Load path'
+                        'description' => 'PHP Sync Load path', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/json_found',
-                        'label' => 'Json: Found',
-                        'value' => '<code>' . (acf_get_setting('acfe/json_found') ? __('True'): __('False')) . '</code>',
-                        'description' => 'Found Json Sync load folder'
+                        'label' => __('Json: Found', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('acfe/json_found') ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Found Json Sync load folder', 'acfe')
                     ),
                 );
                 ?>
@@ -385,7 +385,7 @@ function acfe_admin_settings_html(){
                         
                     acf.newPostbox({
                         'id': 'acfe-settings',
-                        'label': 'left'
+                        'label': __('left', 'acfe')
                     });	
 
                 }

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -59,20 +59,20 @@ function acfe_admin_settings_html(){
                     ),
                     array(
                         'name'  => 'show_admin',
-                        'label' => __('Show menu',
-                        'value' => '<code>' . (acf_get_setting('show_admin') ? __('True'): __('False')) . '</code>',
-                        'description' => __('Show/hide ACF menu item. Defaults to true'
+                        'label' => __('Show menu', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('show_admin') ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'description' => __('Show/hide ACF menu item. Defaults to true', 'acfe')
                     ),
                     array(
                         'name'  => 'stripslashes',
-                        'label' => __('Strip slashes, 'acfe')',
-                        'value' => '<code>' . (acf_get_setting('stripslashes') ? __('True'): __('False')) . '</code>',
+                        'label' =>  __('Strip slashes', 'acfe'),
+                        'value' => '<code>' . (acf_get_setting('stripslashes') ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
                         'description' => __('Runs the function stripslashes on all $_POST data. Some servers / WP instals may require this extra functioanlity. Defaults to false', 'acfe')
                     ),
                     array(
                         'name'  => 'local',
                         'label' => __('PHP/Json', 'acfe'),
-                        'value' => '<code>' . (acf_get_setting('local') ? __('True'): __('False')) . '</code>',
+                        'value' => '<code>' . (acf_get_setting('local') ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
                         'description' => __('Enable/Disable local (PHP/json) fields. Defaults to true', 'acfe')
                     ),
                     array(
@@ -120,14 +120,14 @@ function acfe_admin_settings_html(){
                     array(
                         'name'  => 'export_textdomain',
                         'label' => __('Export textdomain', 'acfe'),
-                        'value' => '<code>' . (acf_get_setting('export_textdomain') ? __('True'): __('False')) . '</code>',
+                        'value' => '<code>' . (acf_get_setting('export_textdomain') ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
                         'description' => __('Array of keys used during the ‘Export to PHP’ feature to wrap strings within the __() function.<br />Defaults to array(’title’, ’label’, ’instructions’). Depreciated in v5.3.4 – please see l10n_field and l10n_field_group', 'acfe')
                     ),
                     array(
                         'name'  => 'export_translate',
                         'label' => __('Export translate', 'acfe'),
                         'value' => '<code>' . print_r(acf_get_setting('export_translate'), true) . '</code>',
-                        'description' => __('Used during the ‘Export to PHP’ feature to wrap strings within the __() function.<br />Depreciated in v5.4.4 – please see l10n_textdomain'
+                        'description' => __('Used during the ‘Export to PHP’ feature to wrap strings within the __() function.<br />Depreciated in v5.4.4 – please see l10n_textdomain', 'acfe')
                     ),
                     array(
                         'name'  => 'autoload',
@@ -187,7 +187,7 @@ function acfe_admin_settings_html(){
                         'name'  => 'select2_version',
                         'label' => __('Select2 version', 'acfe'),
                         'value' => '<code>' . acf_get_setting('select2_version') . '</code>',
-                        'description' => __('Defines which version of Select2 library to enqueue. Either 3 or 4.<br />Defaults to 4 since ACF 5.6.0'
+                        'description' => __('Defines which version of Select2 library to enqueue. Either 3 or 4.<br />Defaults to 4 since ACF 5.6.0', 'acfe')
                     ),
                     array(
                         'name'  => 'enqueue_datepicker',
@@ -232,7 +232,7 @@ function acfe_admin_settings_html(){
                 <?php 
                 acf_render_field_wrap(array(
                     'type'  => 'tab',
-                    'label' => __('ACF: Extended', 'acfe'),
+                    'label' => 'ACF: Extended',
                 ));
                 ?>
                 
@@ -254,7 +254,7 @@ function acfe_admin_settings_html(){
                     array(
                         'name'  => 'acfe/modules/dynamic_block_types',
                         'label' => __('Module: Dynamic Block Types', 'acfe'),
-                        'value' => '<code>' . (acf_get_setting('acfe/modules/dynamic_block_types', true) ? __('True'): __('False', 'acfe')) . '</code>',
+                        'value' => '<code>' . (acf_get_setting('acfe/modules/dynamic_block_types', true) ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
                         'description' => __('Show/hide the Block Types module. Defaults to true', 'acfe')
                     ),
                     array(
@@ -290,7 +290,7 @@ function acfe_admin_settings_html(){
                     array(
                         'name'  => 'acfe/modules/taxonomies',
                         'label' => __('Module: Taxonomies Enhancements', 'acfe'),
-                        'value' => '<code>' . (acf_get_setting('acfe/modules/taxonomies', true) ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
+                        'value' => '<code>' . (acf_get_setting('acfe/modules/taxonomies', true) ? __('True'): __('False')) . '</code>',
                         'description' => __('Show/hide the Taxonomies enhancements module. Defaults to true', 'acfe')
                     ),
                     array(
@@ -344,20 +344,20 @@ function acfe_admin_settings_html(){
                     array(
                         'name'  => 'acfe/php_found',
                         'label' => __('PHP: Found', 'acfe'),
-                        'value' => '<code>' . (acf_get_setting('acfe/php_found') ? __('True'): __('False')) . '</code>',
+                        'value' => '<code>' . (acf_get_setting('acfe/php_found') ? __('True', 'acfe'): __('False', 'acfe')) . '</code>',
                         'description' => __('Found PHP Sync load folder', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/php_save',
                         'label' => __('PHP: Save', 'acfe'),
                         'value' => '<code>' . acf_get_setting('acfe/php_save') . '</code>',
-                        'description' => 'Found PHP Sync save folder', 'acfe')
+                        'description' => __('Found PHP Sync save folder', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/php_load',
                         'label' => __('PHP: Load', 'acfe'),
                         'value' => '<code>' . $load_php_text . '</code>',
-                        'description' => 'PHP Sync Load path', 'acfe')
+                        'description' => __('PHP Sync Load path', 'acfe')
                     ),
                     array(
                         'name'  => 'acfe/json_found',

--- a/includes/admin/tools/dbt-export.php
+++ b/includes/admin/tools/dbt-export.php
@@ -18,7 +18,7 @@ class ACFE_Admin_Tool_Export_DBT extends ACF_Admin_Tool{
         
         // vars
         $this->name = 'acfe_tool_dbt_export';
-        $this->title = __('Export Block Types');
+        $this->title = __('Export Block Types', 'acfe');
         $this->icon = 'dashicons-upload';
         
     }
@@ -58,7 +58,7 @@ class ACFE_Admin_Tool_Export_DBT extends ACF_Admin_Tool{
 		}
         
         ?>
-        <p><?php _e('Export Block Types', 'acf'); ?></p>
+        <p><?php _e('Export Block Types', 'acfe'); ?></p>
         
         <div class="acf-fields">
             <?php 
@@ -67,7 +67,7 @@ class ACFE_Admin_Tool_Export_DBT extends ACF_Admin_Tool{
             
                 // render
                 acf_render_field_wrap(array(
-                    'label'		=> __('Select Block Types', 'acf'),
+                    'label'		=> __('Select Block Types', 'acfe'),
                     'type'		=> 'checkbox',
                     'name'		=> 'keys',
                     'prefix'	=> false,
@@ -81,7 +81,7 @@ class ACFE_Admin_Tool_Export_DBT extends ACF_Admin_Tool{
             else{
                 
                 echo '<div style="padding:15px 12px;">';
-                    _e('No dynamic block type available.');
+                    _e('No dynamic block type available.', 'acfe');
                 echo '</div>'; 
                 
             }
@@ -99,7 +99,7 @@ class ACFE_Admin_Tool_Export_DBT extends ACF_Admin_Tool{
         
         <p class="acf-submit">
             <button type="submit" name="action" class="button button-primary" value="json" <?php echo $disabled; ?>><?php _e('Export File'); ?></button>
-            <button type="submit" name="action" class="button" value="php" <?php echo $disabled; ?>><?php _e('Generate PHP'); ?></button>
+            <button type="submit" name="action" class="button" value="php" <?php echo $disabled; ?>><?php _e('Generate PHP', 'acfe'); ?></button>
         </p>
         <?php
         
@@ -130,7 +130,7 @@ class ACFE_Admin_Tool_Export_DBT extends ACF_Admin_Tool{
 
 
                 ?>
-                <p><?php _e("The following code can be used to register a block type. Simply copy and paste the following code to your theme's functions.php file or include it within an external file.", 'acf'); ?></p>
+                <p><?php _e("The following code can be used to register a block type. Simply copy and paste the following code to your theme's functions.php file or include it within an external file.", 'acfe'); ?></p>
                 
                 <div id="acf-admin-tool-export">
                 
@@ -168,7 +168,7 @@ class ACFE_Admin_Tool_Export_DBT extends ACF_Admin_Tool{
                 </div>
                 
                 <p class="acf-submit">
-                    <a class="button" id="acf-export-copy"><?php _e( 'Copy to clipboard', 'acf' ); ?></a>
+                    <a class="button" id="acf-export-copy"><?php _e( 'Copy to clipboard', 'acfe' ); ?></a>
                 </p>
                 <script type="text/javascript">
                 (function($){
@@ -205,7 +205,7 @@ class ACFE_Admin_Tool_Export_DBT extends ACF_Admin_Tool{
                             
                             // tooltip
                             acf.newTooltip({
-                                text: 		"<?php _e('Copied', 'acf' ); ?>",
+                                text: 		"<?php _e('Copied', 'acfe' ); ?>",
                                 timeout:	250,
                                 target: 	$(this),
                             });
@@ -241,7 +241,7 @@ class ACFE_Admin_Tool_Export_DBT extends ACF_Admin_Tool{
 	    	if(!empty($this->data)){
                 
 		    	$count = count($this->data);
-		    	$text = sprintf(_n( 'Exported 1 block type.', 'Exported %s block types.', $count, 'acf' ), $count);
+		    	$text = sprintf(_n( 'Exported 1 block type.', 'Exported %s block types.', $count, 'acfe' ), $count);
                 
 		    	acf_add_admin_notice($text, 'success');
                 
@@ -258,7 +258,7 @@ class ACFE_Admin_Tool_Export_DBT extends ACF_Admin_Tool{
         
         // validate
 		if($this->data === false)
-			return acf_add_admin_notice(__('No block types selected'), 'warning');
+			return acf_add_admin_notice(__('No block types selected', 'acfe'), 'warning');
         
         $keys = array();
         foreach($this->data as $key => $args){

--- a/includes/admin/tools/dbt-import.php
+++ b/includes/admin/tools/dbt-import.php
@@ -15,7 +15,7 @@ class ACFE_Admin_Tool_Import_DBT extends ACF_Admin_Tool{
         
         // vars
         $this->name = 'acfe_tool_dbt_import';
-        $this->title = __('Import Block Types');
+        $this->title = __('Import Block Types', 'acfe');
         $this->icon = 'dashicons-upload';
         
     }
@@ -23,13 +23,13 @@ class ACFE_Admin_Tool_Import_DBT extends ACF_Admin_Tool{
     function html(){
         
         ?>
-        <p><?php _e('Import Block Types', 'acf'); ?></p>
+        <p><?php _e('Import Block Types', 'acfe'); ?></p>
         
         <div class="acf-fields">
             <?php 
 			
 			acf_render_field_wrap(array(
-				'label'		=> __('Select File', 'acf'),
+				'label'		=> __('Select File', 'acfe'),
 				'type'		=> 'file',
 				'name'		=> 'acf_import_file',
 				'value'		=> false,
@@ -40,7 +40,7 @@ class ACFE_Admin_Tool_Import_DBT extends ACF_Admin_Tool{
         </div>
         
         <p class="acf-submit">
-            <button type="submit" name="action" class="button button-primary"><?php _e('Import File'); ?></button>
+            <button type="submit" name="action" class="button button-primary"><?php _e('Import File', 'acfe'); ?></button>
         </p>
         <?php
         
@@ -50,18 +50,18 @@ class ACFE_Admin_Tool_Import_DBT extends ACF_Admin_Tool{
         
         // Check file size.
 		if(empty($_FILES['acf_import_file']['size']))
-			return acf_add_admin_notice(__("No file selected", 'acf'), 'warning');
+			return acf_add_admin_notice(__("No file selected", 'acfe'), 'warning');
 		
 		// Get file data.
 		$file = $_FILES['acf_import_file'];
 		
 		// Check errors.
 		if($file['error'])
-			return acf_add_admin_notice(__("Error uploading file. Please try again", 'acf'), 'warning');
+			return acf_add_admin_notice(__("Error uploading file. Please try again", 'acfe'), 'warning');
 		
 		// Check file type.
 		if(pathinfo($file['name'], PATHINFO_EXTENSION) !== 'json')
-			return acf_add_admin_notice(__("Incorrect file type", 'acf'), 'warning');
+			return acf_add_admin_notice(__("Incorrect file type", 'acfe'), 'warning');
 		
 		// Read JSON.
 		$json = file_get_contents($file['tmp_name']);
@@ -69,7 +69,7 @@ class ACFE_Admin_Tool_Import_DBT extends ACF_Admin_Tool{
 		
 		// Check if empty.
     	if(!$json || !is_array($json))
-    		return acf_add_admin_notice(__("Import file empty", 'acf'), 'warning');
+    		return acf_add_admin_notice(__("Import file empty", 'acfe'), 'warning');
     	
     	$ids = array();
         
@@ -81,7 +81,7 @@ class ACFE_Admin_Tool_Import_DBT extends ACF_Admin_Tool{
             // Check if already exists
             if(isset($dynamic_block_types[$block_type_name])){
                 
-                acf_add_admin_notice(__("Block type {$dynamic_block_types[$block_type_name]['title']} already exists. Import aborted."), 'warning');
+                acf_add_admin_notice(__("Block type {$dynamic_block_types[$block_type_name]['title']} already exists. Import aborted.", 'acfe'), 'warning');
                 continue;
                 
             }
@@ -101,7 +101,7 @@ class ACFE_Admin_Tool_Import_DBT extends ACF_Admin_Tool{
             // Insert error
             if(is_wp_error($post_id)){
                 
-                acf_add_admin_notice(__("Something went wrong with the block type {$title}. Import aborted."), 'warning');
+                acf_add_admin_notice(__("Something went wrong with the block type {$title}. Import aborted.", 'acfe'), 'warning');
                 continue;
                 
             }
@@ -195,7 +195,7 @@ class ACFE_Admin_Tool_Import_DBT extends ACF_Admin_Tool{
 		$total = count($ids);
 		
 		// Generate text
-		$text = sprintf(_n('1 block type imported', '%s block types imported', $total, 'acf'), $total);		
+		$text = sprintf(_n('1 block type imported', '%s block types imported', $total, 'acfe'), $total);		
 		
 		// Add links to text
 		$links = array();

--- a/includes/admin/tools/dop-export.php
+++ b/includes/admin/tools/dop-export.php
@@ -18,7 +18,7 @@ class ACFE_Admin_Tool_Export_DOP extends ACF_Admin_Tool{
         
         // vars
         $this->name = 'acfe_tool_dop_export';
-        $this->title = __('Export Options Pages');
+        $this->title = __('Export Options Pages', 'acfe');
         $this->icon = 'dashicons-upload';
         
     }
@@ -56,7 +56,7 @@ class ACFE_Admin_Tool_Export_DOP extends ACF_Admin_Tool{
 		}
         
         ?>
-        <p><?php _e('Export Options Pages', 'acf'); ?></p>
+        <p><?php _e('Export Options Pages', 'acfe'); ?></p>
         
         <div class="acf-fields">
             <?php 
@@ -65,7 +65,7 @@ class ACFE_Admin_Tool_Export_DOP extends ACF_Admin_Tool{
             
                 // render
                 acf_render_field_wrap(array(
-                    'label'		=> __('Select Options Pages', 'acf'),
+                    'label'		=> __('Select Options Pages', 'acfe'),
                     'type'		=> 'checkbox',
                     'name'		=> 'keys',
                     'prefix'	=> false,
@@ -79,7 +79,7 @@ class ACFE_Admin_Tool_Export_DOP extends ACF_Admin_Tool{
             else{
                 
                 echo '<div style="padding:15px 12px;">';
-                    _e('No options page available.');
+                    _e('No options page available.', 'acfe');
                 echo '</div>'; 
                 
             }
@@ -96,8 +96,8 @@ class ACFE_Admin_Tool_Export_DOP extends ACF_Admin_Tool{
         ?>
         
         <p class="acf-submit">
-            <button type="submit" name="action" class="button button-primary" value="json" <?php echo $disabled; ?>><?php _e('Export File'); ?></button>
-            <button type="submit" name="action" class="button" value="php" <?php echo $disabled; ?>><?php _e('Generate PHP'); ?></button>
+            <button type="submit" name="action" class="button button-primary" value="json" <?php echo $disabled; ?>><?php _e('Export File', 'acfe'); ?></button>
+            <button type="submit" name="action" class="button" value="php" <?php echo $disabled; ?>><?php _e('Generate PHP', 'acfe'); ?></button>
         </p>
         <?php
         
@@ -128,7 +128,7 @@ class ACFE_Admin_Tool_Export_DOP extends ACF_Admin_Tool{
 
 
                 ?>
-                <p><?php _e("The following code can be used to register a option page. Simply copy and paste the following code to your theme's functions.php file or include it within an external file.", 'acf'); ?></p>
+                <p><?php _e("The following code can be used to register a option page. Simply copy and paste the following code to your theme's functions.php file or include it within an external file.", 'acfe'); ?></p>
                 
                 <div id="acf-admin-tool-export">
                 
@@ -140,19 +140,15 @@ class ACFE_Admin_Tool_Export_DOP extends ACF_Admin_Tool{
                                 
                         // code
                         $code = var_export($args, true);
-                        
-                        
+                    
                         // change double spaces to tabs
                         $code = str_replace( array_keys($str_replace), array_values($str_replace), $code );
-                        
                         
                         // correctly formats "=> array("
                         $code = preg_replace( array_keys($preg_replace), array_values($preg_replace), $code );
                         
-                        
                         // esc_textarea
                         $code = esc_textarea( $code );
-                        
                         
                         // echo
                         echo "acf_add_options_page({$code});" . "\r\n" . "\r\n";
@@ -166,7 +162,7 @@ class ACFE_Admin_Tool_Export_DOP extends ACF_Admin_Tool{
                 </div>
                 
                 <p class="acf-submit">
-                    <a class="button" id="acf-export-copy"><?php _e( 'Copy to clipboard', 'acf' ); ?></a>
+                    <a class="button" id="acf-export-copy"><?php _e( 'Copy to clipboard', 'acfe' ); ?></a>
                 </p>
                 <script type="text/javascript">
                 (function($){
@@ -239,7 +235,7 @@ class ACFE_Admin_Tool_Export_DOP extends ACF_Admin_Tool{
 	    	if(!empty($this->data)){
                 
 		    	$count = count($this->data);
-		    	$text = sprintf(_n( 'Exported 1 option page.', 'Exported %s option pages.', $count, 'acf' ), $count);
+		    	$text = sprintf(_n( 'Exported 1 option page.', 'Exported %s option pages.', $count, 'acfe' ), $count);
                 
 		    	acf_add_admin_notice($text, 'success');
                 
@@ -256,7 +252,7 @@ class ACFE_Admin_Tool_Export_DOP extends ACF_Admin_Tool{
         
         // validate
 		if($this->data === false)
-			return acf_add_admin_notice(__('No options page selected'), 'warning');
+			return acf_add_admin_notice(__('No options page selected', 'acfe'), 'warning');
         
         $keys = array();
         foreach($this->data as $key => $args){
@@ -374,6 +370,7 @@ class ACFE_Admin_Tool_Export_DOP extends ACF_Admin_Tool{
         return $type;
 		
 	}
+
     
 }
 

--- a/includes/admin/tools/dop-import.php
+++ b/includes/admin/tools/dop-import.php
@@ -15,7 +15,7 @@ class ACFE_Admin_Tool_Import_DOP extends ACF_Admin_Tool{
         
         // vars
         $this->name = 'acfe_tool_dop_import';
-        $this->title = __('Import Options Pages');
+        $this->title = __('Import Options Pages', 'acfe');
         $this->icon = 'dashicons-upload';
         
     }
@@ -23,13 +23,13 @@ class ACFE_Admin_Tool_Import_DOP extends ACF_Admin_Tool{
     function html(){
         
         ?>
-        <p><?php _e('Import Options Pages', 'acf'); ?></p>
+        <p><?php _e('Import Options Pages', 'acfe'); ?></p>
         
         <div class="acf-fields">
             <?php 
 			
 			acf_render_field_wrap(array(
-				'label'		=> __('Select File', 'acf'),
+				'label'		=> __('Select File', 'acfe'),
 				'type'		=> 'file',
 				'name'		=> 'acf_import_file',
 				'value'		=> false,
@@ -40,7 +40,7 @@ class ACFE_Admin_Tool_Import_DOP extends ACF_Admin_Tool{
         </div>
         
         <p class="acf-submit">
-            <button type="submit" name="action" class="button button-primary"><?php _e('Import File'); ?></button>
+            <button type="submit" name="action" class="button button-primary"><?php _e('Import File', 'acfe'); ?></button>
         </p>
         <?php
         
@@ -50,7 +50,7 @@ class ACFE_Admin_Tool_Import_DOP extends ACF_Admin_Tool{
         
         // Check file size.
 		if(empty($_FILES['acf_import_file']['size']))
-			return acf_add_admin_notice(__("No file selected", 'acf'), 'warning');
+			return acf_add_admin_notice(__("No file selected", 'acfe'), 'warning');
 		
 		// Get file data.
 		$file = $_FILES['acf_import_file'];
@@ -69,7 +69,7 @@ class ACFE_Admin_Tool_Import_DOP extends ACF_Admin_Tool{
 		
 		// Check if empty.
     	if(!$json || !is_array($json))
-    		return acf_add_admin_notice(__("Import file empty", 'acf'), 'warning');
+    		return acf_add_admin_notice(__("Import file empty", 'acfe'), 'warning');
     	
     	$ids = array();
         
@@ -83,7 +83,7 @@ class ACFE_Admin_Tool_Import_DOP extends ACF_Admin_Tool{
             // Check if already exists
             if(isset($dynamic_options_pages[$options_page_name])){
                 
-                acf_add_admin_notice(__("Options page {$dynamic_options_pages[$options_page_name]['page_title']} already exists. Import aborted."), 'warning');
+                acf_add_admin_notice(__("Options page {$dynamic_options_pages[$options_page_name]['page_title']} already exists. Import aborted.", 'acfe')), 'warning');
                 continue;
                 
             }
@@ -103,7 +103,7 @@ class ACFE_Admin_Tool_Import_DOP extends ACF_Admin_Tool{
             // Insert error
             if(is_wp_error($post_id)){
                 
-                acf_add_admin_notice(__("Something went wrong with the options page {$title}. Import aborted."), 'warning');
+                acf_add_admin_notice(__("Something went wrong with the options page {$title}. Import aborted.", 'acfe')), 'warning');
                 continue;
                 
             }
@@ -182,7 +182,7 @@ class ACFE_Admin_Tool_Import_DOP extends ACF_Admin_Tool{
 		$total = count($ids);
 		
 		// Generate text
-		$text = sprintf(_n('1 options page imported', '%s options pages imported', $total, 'acf'), $total);		
+		$text = sprintf(_n('1 options page imported', '%s options pages imported', $total, 'acfe'), $total);		
 		
 		// Add links to text
 		$links = array();

--- a/includes/admin/tools/dpt-export.php
+++ b/includes/admin/tools/dpt-export.php
@@ -18,7 +18,7 @@ class ACFE_Admin_Tool_Export_DPT extends ACF_Admin_Tool{
         
         // vars
         $this->name = 'acfe_tool_dpt_export';
-        $this->title = __('Export Post Types');
+        $this->title = __('Export Post Types', 'acfe');
         $this->icon = 'dashicons-upload';
         
     }
@@ -56,7 +56,7 @@ class ACFE_Admin_Tool_Export_DPT extends ACF_Admin_Tool{
         }
         
         ?>
-        <p><?php _e('Export Post Types', 'acf'); ?></p>
+        <p><?php _e('Export Post Types', 'acfe'); ?></p>
         
         <div class="acf-fields">
             <?php 
@@ -65,7 +65,7 @@ class ACFE_Admin_Tool_Export_DPT extends ACF_Admin_Tool{
             
                 // render
                 acf_render_field_wrap(array(
-                    'label'		=> __('Select Post Types', 'acf'),
+                    'label'		=> __('Select Post Types', 'acfe'),
                     'type'		=> 'checkbox',
                     'name'		=> 'keys',
                     'prefix'	=> false,
@@ -79,7 +79,7 @@ class ACFE_Admin_Tool_Export_DPT extends ACF_Admin_Tool{
             else{
                 
                 echo '<div style="padding:15px 12px;">';
-                    _e('No dynamic post type available.');
+                    _e('No dynamic post type available.', 'acfe');
                 echo '</div>'; 
                 
             }
@@ -97,7 +97,7 @@ class ACFE_Admin_Tool_Export_DPT extends ACF_Admin_Tool{
         
         <p class="acf-submit">
             <button type="submit" name="action" class="button button-primary" value="json" <?php echo $disabled; ?>><?php _e('Export File'); ?></button>
-            <button type="submit" name="action" class="button" value="php" <?php echo $disabled; ?>><?php _e('Generate PHP'); ?></button>
+            <button type="submit" name="action" class="button" value="php" <?php echo $disabled; ?>><?php _e('Generate PHP', 'acfe'); ?></button>
         </p>
         <?php
         
@@ -128,7 +128,7 @@ class ACFE_Admin_Tool_Export_DPT extends ACF_Admin_Tool{
 
 
                 ?>
-                <p><?php _e("The following code can be used to register a post type. Simply copy and paste the following code to your theme's functions.php file or include it within an external file.", 'acf'); ?></p>
+                <p><?php _e("The following code can be used to register a post type. Simply copy and paste the following code to your theme's functions.php file or include it within an external file.", 'acfe'); ?></p>
                 
                 <div id="acf-admin-tool-export">
                 
@@ -162,7 +162,7 @@ class ACFE_Admin_Tool_Export_DPT extends ACF_Admin_Tool{
                 </div>
                 
                 <p class="acf-submit">
-                    <a class="button" id="acf-export-copy"><?php _e( 'Copy to clipboard', 'acf' ); ?></a>
+                    <a class="button" id="acf-export-copy"><?php _e( 'Copy to clipboard', 'acfe' ); ?></a>
                 </p>
                 <script type="text/javascript">
                 (function($){
@@ -199,7 +199,7 @@ class ACFE_Admin_Tool_Export_DPT extends ACF_Admin_Tool{
                             
                             // tooltip
                             acf.newTooltip({
-                                text: 		"<?php _e('Copied', 'acf' ); ?>",
+                                text: 		"<?php _e('Copied', 'acfe' ); ?>",
                                 timeout:	250,
                                 target: 	$(this),
                             });
@@ -235,7 +235,7 @@ class ACFE_Admin_Tool_Export_DPT extends ACF_Admin_Tool{
 	    	if(!empty($this->data)){
                 
 		    	$count = count($this->data);
-		    	$text = sprintf(_n( 'Exported 1 post type.', 'Exported %s post types.', $count, 'acf' ), $count);
+		    	$text = sprintf(_n( 'Exported 1 post type.', 'Exported %s post types.', $count, 'acfe' ), $count);
                 
 		    	acf_add_admin_notice($text, 'success');
                 
@@ -252,7 +252,7 @@ class ACFE_Admin_Tool_Export_DPT extends ACF_Admin_Tool{
         
         // validate
 		if($this->data === false)
-			return acf_add_admin_notice(__('No post types selected'), 'warning');
+			return acf_add_admin_notice(__('No post types selected', 'acfe'), 'warning');
         
         $keys = array();
         foreach($this->data as $key => $args){

--- a/includes/admin/tools/dpt-import.php
+++ b/includes/admin/tools/dpt-import.php
@@ -15,7 +15,7 @@ class ACFE_Admin_Tool_Import_DPT extends ACF_Admin_Tool{
         
         // vars
         $this->name = 'acfe_tool_dpt_import';
-        $this->title = __('Import Post Types');
+        $this->title = __('Import Post Types', 'acfe');
         $this->icon = 'dashicons-upload';
         
     }
@@ -23,13 +23,13 @@ class ACFE_Admin_Tool_Import_DPT extends ACF_Admin_Tool{
     function html(){
         
         ?>
-        <p><?php _e('Import Post Types', 'acf'); ?></p>
+        <p><?php _e('Import Post Types', 'acfe'); ?></p>
         
         <div class="acf-fields">
             <?php 
 			
 			acf_render_field_wrap(array(
-				'label'		=> __('Select File', 'acf'),
+				'label'		=> __('Select File', 'acfe'),
 				'type'		=> 'file',
 				'name'		=> 'acf_import_file',
 				'value'		=> false,
@@ -40,7 +40,7 @@ class ACFE_Admin_Tool_Import_DPT extends ACF_Admin_Tool{
         </div>
         
         <p class="acf-submit">
-            <button type="submit" name="action" class="button button-primary"><?php _e('Import File'); ?></button>
+            <button type="submit" name="action" class="button button-primary"><?php _e('Import File', 'acfe'); ?></button>
         </p>
         <?php
         
@@ -50,18 +50,18 @@ class ACFE_Admin_Tool_Import_DPT extends ACF_Admin_Tool{
         
         // Check file size.
 		if(empty($_FILES['acf_import_file']['size']))
-			return acf_add_admin_notice(__("No file selected", 'acf'), 'warning');
+			return acf_add_admin_notice(__("No file selected", 'acfe'), 'warning');
 		
 		// Get file data.
 		$file = $_FILES['acf_import_file'];
 		
 		// Check errors.
 		if($file['error'])
-			return acf_add_admin_notice(__("Error uploading file. Please try again", 'acf'), 'warning');
+			return acf_add_admin_notice(__("Error uploading file. Please try again", 'acfe'), 'warning');
 		
 		// Check file type.
 		if(pathinfo($file['name'], PATHINFO_EXTENSION) !== 'json')
-			return acf_add_admin_notice(__("Incorrect file type", 'acf'), 'warning');
+			return acf_add_admin_notice(__("Incorrect file type", 'acfe'), 'warning');
 		
 		// Read JSON.
 		$json = file_get_contents($file['tmp_name']);
@@ -69,7 +69,7 @@ class ACFE_Admin_Tool_Import_DPT extends ACF_Admin_Tool{
 		
 		// Check if empty.
     	if(!$json || !is_array($json))
-    		return acf_add_admin_notice(__("Import file empty", 'acf'), 'warning');
+    		return acf_add_admin_notice(__("Import file empty", 'acfe'), 'warning');
     	
     	$ids = array();
         
@@ -81,7 +81,7 @@ class ACFE_Admin_Tool_Import_DPT extends ACF_Admin_Tool{
             // Check if already exists
             if(isset($dynamic_post_types[$post_type_name])){
                 
-                acf_add_admin_notice(__("Post type {$dynamic_post_types[$post_type_name]['label']} already exists. Import aborted."), 'warning');
+                acf_add_admin_notice(__("Post type {$dynamic_post_types[$post_type_name]['label']} already exists. Import aborted.", 'acfe'), 'warning');
                 continue;
                 
             }
@@ -101,7 +101,7 @@ class ACFE_Admin_Tool_Import_DPT extends ACF_Admin_Tool{
             // Insert error
             if(is_wp_error($post_id)){
                 
-                acf_add_admin_notice(__("Something went wrong with the post type {$title}. Import aborted."), 'warning');
+                acf_add_admin_notice(__("Something went wrong with the post type {$title}. Import aborted.", 'acfe'), 'warning');
                 continue;
                 
             }
@@ -216,7 +216,7 @@ class ACFE_Admin_Tool_Import_DPT extends ACF_Admin_Tool{
 		$total = count($ids);
 		
 		// Generate text
-		$text = sprintf(_n('1 post type imported', '%s post types imported', $total, 'acf'), $total);		
+		$text = sprintf(_n('1 post type imported', '%s post types imported', $total, 'acfe'), $total);		
 		
 		// Add links to text
 		$links = array();

--- a/includes/admin/tools/dt-export.php
+++ b/includes/admin/tools/dt-export.php
@@ -18,7 +18,7 @@ class ACFE_Admin_Tool_Export_DT extends ACF_Admin_Tool{
         
         // vars
         $this->name = 'acfe_tool_dt_export';
-        $this->title = __('Export Taxonomies');
+        $this->title = __('Export Taxonomies', 'acfe');
         $this->icon = 'dashicons-upload';
         
     }
@@ -56,7 +56,7 @@ class ACFE_Admin_Tool_Export_DT extends ACF_Admin_Tool{
 		}
         
         ?>
-        <p><?php _e('Export Taxonomies', 'acf'); ?></p>
+        <p><?php _e('Export Taxonomies', 'acfe'); ?></p>
         
         <div class="acf-fields">
             <?php 
@@ -65,7 +65,7 @@ class ACFE_Admin_Tool_Export_DT extends ACF_Admin_Tool{
             
                 // render
                 acf_render_field_wrap(array(
-                    'label'		=> __('Select Taxonomies', 'acf'),
+                    'label'		=> __('Select Taxonomies', 'acfe'),
                     'type'		=> 'checkbox',
                     'name'		=> 'keys',
                     'prefix'	=> false,
@@ -79,7 +79,7 @@ class ACFE_Admin_Tool_Export_DT extends ACF_Admin_Tool{
             else{
                 
                 echo '<div style="padding:15px 12px;">';
-                    _e('No dynamic taxonomy available.');
+                    _e('No dynamic taxonomy available.', 'acfe');
                 echo '</div>'; 
                 
             }
@@ -128,7 +128,7 @@ class ACFE_Admin_Tool_Export_DT extends ACF_Admin_Tool{
 
 
                 ?>
-                <p><?php _e("The following code can be used to register a taxonomy. Simply copy and paste the following code to your theme's functions.php file or include it within an external file.", 'acf'); ?></p>
+                <p><?php _e("The following code can be used to register a taxonomy. Simply copy and paste the following code to your theme's functions.php file or include it within an external file.", 'acfe'); ?></p>
                 
                 <div id="acf-admin-tool-export">
                 
@@ -173,7 +173,7 @@ class ACFE_Admin_Tool_Export_DT extends ACF_Admin_Tool{
                 </div>
                 
                 <p class="acf-submit">
-                    <a class="button" id="acf-export-copy"><?php _e( 'Copy to clipboard', 'acf' ); ?></a>
+                    <a class="button" id="acf-export-copy"><?php _e( 'Copy to clipboard', 'acfe' ); ?></a>
                 </p>
                 <script type="text/javascript">
                 (function($){
@@ -210,7 +210,7 @@ class ACFE_Admin_Tool_Export_DT extends ACF_Admin_Tool{
                             
                             // tooltip
                             acf.newTooltip({
-                                text: 		"<?php _e('Copied', 'acf' ); ?>",
+                                text: 		"<?php _e('Copied', 'acfe' ); ?>",
                                 timeout:	250,
                                 target: 	$(this),
                             });
@@ -246,7 +246,7 @@ class ACFE_Admin_Tool_Export_DT extends ACF_Admin_Tool{
 	    	if(!empty($this->data)){
                 
 		    	$count = count($this->data);
-		    	$text = sprintf(_n( 'Exported 1 taxonomy.', 'Exported %s taxonomies.', $count, 'acf' ), $count);
+		    	$text = sprintf(_n( 'Exported 1 taxonomy.', 'Exported %s taxonomies.', $count, 'acfe' ), $count);
                 
 		    	acf_add_admin_notice($text, 'success');
                 

--- a/includes/admin/tools/dt-import.php
+++ b/includes/admin/tools/dt-import.php
@@ -15,7 +15,7 @@ class ACFE_Admin_Tool_Import_DT extends ACF_Admin_Tool{
         
         // vars
         $this->name = 'acfe_tool_dt_import';
-        $this->title = __('Import Taxonomies');
+        $this->title = __('Import Taxonomies', 'acfe'). ;
         $this->icon = 'dashicons-upload';
         
     }
@@ -23,13 +23,13 @@ class ACFE_Admin_Tool_Import_DT extends ACF_Admin_Tool{
     function html(){
         
         ?>
-        <p><?php _e('Import Taxonomies', 'acf'); ?></p>
+        <p><?php _e('Import Taxonomies', 'acfe'); ?></p>
         
         <div class="acf-fields">
             <?php 
 			
 			acf_render_field_wrap(array(
-				'label'		=> __('Select File', 'acf'),
+				'label'		=> __('Select File', 'acfe'),
 				'type'		=> 'file',
 				'name'		=> 'acf_import_file',
 				'value'		=> false,
@@ -40,7 +40,7 @@ class ACFE_Admin_Tool_Import_DT extends ACF_Admin_Tool{
         </div>
         
         <p class="acf-submit">
-            <button type="submit" name="action" class="button button-primary"><?php _e('Import File'); ?></button>
+            <button type="submit" name="action" class="button button-primary"><?php _e('Import File', 'acfe'); ?></button>
         </p>
         <?php
         
@@ -50,18 +50,18 @@ class ACFE_Admin_Tool_Import_DT extends ACF_Admin_Tool{
         
         // Check file size.
 		if(empty($_FILES['acf_import_file']['size']))
-			return acf_add_admin_notice(__("No file selected", 'acf'), 'warning');
+			return acf_add_admin_notice(__("No file selected", 'acfe'), 'warning');
 		
 		// Get file data.
 		$file = $_FILES['acf_import_file'];
 		
 		// Check errors.
 		if($file['error'])
-			return acf_add_admin_notice(__("Error uploading file. Please try again", 'acf'), 'warning');
+			return acf_add_admin_notice(__("Error uploading file. Please try again", 'acfe'), 'warning');
 		
 		// Check file type.
 		if(pathinfo($file['name'], PATHINFO_EXTENSION) !== 'json')
-			return acf_add_admin_notice(__("Incorrect file type", 'acf'), 'warning');
+			return acf_add_admin_notice(__("Incorrect file type", 'acfe'), 'warning');
 		
 		// Read JSON.
 		$json = file_get_contents($file['tmp_name']);
@@ -69,7 +69,7 @@ class ACFE_Admin_Tool_Import_DT extends ACF_Admin_Tool{
 		
 		// Check if empty.
     	if(!$json || !is_array($json))
-    		return acf_add_admin_notice(__("Import file empty", 'acf'), 'warning');
+    		return acf_add_admin_notice(__("Import file empty", 'acfe'), 'warning');
     	
     	$ids = array();
         
@@ -81,7 +81,7 @@ class ACFE_Admin_Tool_Import_DT extends ACF_Admin_Tool{
             // Check if already exists
             if(isset($dynamic_taxonomies[$taxonomy_name])){
                 
-                acf_add_admin_notice(__("Taxonomy {$dynamic_taxonomies[$taxonomy_name]['label']} already exists. Import aborted."), 'warning');
+                acf_add_admin_notice(__("Taxonomy {$dynamic_taxonomies[$taxonomy_name]['label']} already exists. Import aborted.", 'acfe'), 'warning');
                 continue;
                 
             }
@@ -101,7 +101,7 @@ class ACFE_Admin_Tool_Import_DT extends ACF_Admin_Tool{
             // Insert error
             if(is_wp_error($post_id)){
                 
-                acf_add_admin_notice(__("Something went wrong with the taxonomy {$title}. Import aborted."), 'warning');
+                acf_add_admin_notice(__("Something went wrong with the taxonomy {$title}. Import aborted.", 'acfe'), 'warning');
                 continue;
                 
             }
@@ -214,7 +214,7 @@ class ACFE_Admin_Tool_Import_DT extends ACF_Admin_Tool{
 		$total = count($ids);
 		
 		// Generate text
-		$text = sprintf(_n('1 taxonomy imported', '%s taxonomies imported', $total, 'acf'), $total);		
+		$text = sprintf(_n('1 taxonomy imported', '%s taxonomies imported', $total, 'acfe'), $total);		
 		
 		// Add links to text
 		$links = array();

--- a/includes/admin/tools/fg-export.php
+++ b/includes/admin/tools/fg-export.php
@@ -33,7 +33,7 @@ class ACFE_Admin_Tool_Export_FG extends ACF_Admin_Tool{
             // add notice
             if( $selected ) {
                 $count = count($selected);
-                $text = sprintf( _n( 'Exported 1 field group.', 'Exported %s field groups.', $count, 'acf' ), $count );
+                $text = sprintf( _n( 'Exported 1 field group.', 'Exported %s field groups.', $count, 'acfe'), $count );
                 acf_add_admin_notice( $text, 'success' );
             }
         }

--- a/includes/admin/tools/fg-local.php
+++ b/includes/admin/tools/fg-local.php
@@ -10,7 +10,7 @@ class ACFE_Admin_Tool_FG_Local extends ACF_Admin_Tool{
     function initialize(){
         
         // vars
-        $this->title = __('Export Local Field Groups');
+        $this->title = __('Export Local Field Groups', 'acfe');
         $this->name = 'acfe-fg-local';
         $this->icon = 'dashicons-upload';
         
@@ -26,7 +26,7 @@ class ACFE_Admin_Tool_FG_Local extends ACF_Admin_Tool{
             $total = count($ids);
             
             // Generate text.
-            $text = sprintf( _n( 'Imported 1 field group', 'Imported %s field groups', $total, 'acf' ), $total );		
+            $text = sprintf( _n( 'Imported 1 field group', 'Imported %s field groups', $total, 'acfe' ), $total );		
             
             // Add links to text.
             $links = array();
@@ -48,7 +48,7 @@ class ACFE_Admin_Tool_FG_Local extends ACF_Admin_Tool{
             
             // validate
             if($array === false)
-                return acf_add_admin_notice(__('No field group selected'), 'warning');
+                return acf_add_admin_notice(__('No field group selected', 'acfe'), 'warning');
             
             // Json
             if($action === 'json'){
@@ -145,7 +145,7 @@ class ACFE_Admin_Tool_FG_Local extends ACF_Admin_Tool{
 
 
                     ?>
-                    <p><?php _e("The following code can be used to register a local version of the selected field group(s). A local field group can provide many benefits such as faster load times, version control & dynamic fields/settings. Simply copy and paste the following code to your theme's functions.php file or include it within an external file.", 'acf'); ?></p>
+                    <p><?php _e("The following code can be used to register a local version of the selected field group(s). A local field group can provide many benefits such as faster load times, version control & dynamic fields/settings. Simply copy and paste the following code to your theme's functions.php file or include it within an external file.", 'acfe'); ?></p>
                     
                     <div id="acf-admin-tool-export">
                     
@@ -183,7 +183,7 @@ class ACFE_Admin_Tool_FG_Local extends ACF_Admin_Tool{
                     </div>
                     
                     <p class="acf-submit">
-                        <a class="button" id="acf-export-copy"><?php _e( 'Copy to clipboard', 'acf' ); ?></a>
+                        <a class="button" id="acf-export-copy"><?php _e( 'Copy to clipboard', 'acfe' ); ?></a>
                     </p>
                     <script type="text/javascript">
                     (function($){
@@ -220,7 +220,7 @@ class ACFE_Admin_Tool_FG_Local extends ACF_Admin_Tool{
                                 
                                 // tooltip
                                 acf.newTooltip({
-                                    text: 		"<?php _e('Copied', 'acf' ); ?>",
+                                    text: 		"<?php _e('Copied', 'acfe' ); ?>",
                                     timeout:	250,
                                     target: 	$(this),
                                 });

--- a/includes/admin/tools/form-export.php
+++ b/includes/admin/tools/form-export.php
@@ -18,7 +18,7 @@ class ACFE_Admin_Tool_Export_Form extends ACF_Admin_Tool{
         
         // vars
         $this->name = 'acfe_tool_form_export';
-        $this->title = __('Export Forms');
+        $this->title = __('Export Forms', 'acfe');
         $this->icon = 'dashicons-upload';
         
     }
@@ -56,7 +56,7 @@ class ACFE_Admin_Tool_Export_Form extends ACF_Admin_Tool{
         }
         
         ?>
-        <p><?php _e('Export Forms', 'acf'); ?></p>
+        <p><?php _e('Export Forms', 'acfe'); ?></p>
         
         <div class="acf-fields">
             <?php 
@@ -65,7 +65,7 @@ class ACFE_Admin_Tool_Export_Form extends ACF_Admin_Tool{
             
                 // render
                 acf_render_field_wrap(array(
-                    'label'		=> __('Select Forms', 'acf'),
+                    'label'		=> __('Select Forms', 'acfe'),
                     'type'		=> 'checkbox',
                     'name'		=> 'keys',
                     'prefix'	=> false,
@@ -79,7 +79,7 @@ class ACFE_Admin_Tool_Export_Form extends ACF_Admin_Tool{
             else{
                 
                 echo '<div style="padding:15px 12px;">';
-                    _e('No dynamic form available.');
+                    _e('No dynamic form available.', 'acfe');
                 echo '</div>'; 
                 
             }
@@ -96,7 +96,7 @@ class ACFE_Admin_Tool_Export_Form extends ACF_Admin_Tool{
         ?>
         
         <p class="acf-submit">
-            <button type="submit" name="action" class="button button-primary" value="json" <?php echo $disabled; ?>><?php _e('Export File'); ?></button>
+            <button type="submit" name="action" class="button button-primary" value="json" <?php echo $disabled; ?>><?php _e('Export File', 'acfe')?>; ?></button>
         </p>
         <?php
         
@@ -117,7 +117,7 @@ class ACFE_Admin_Tool_Export_Form extends ACF_Admin_Tool{
 	    	if(!empty($this->data)){
                 
 		    	$count = count($this->data);
-		    	$text = sprintf(_n( 'Exported 1 form.', 'Exported %s forms.', $count, 'acf' ), $count);
+		    	$text = sprintf(_n( 'Exported 1 form.', 'Exported %s forms.', $count, 'acfe' ), $count);
                 
 		    	acf_add_admin_notice($text, 'success');
                 
@@ -134,7 +134,7 @@ class ACFE_Admin_Tool_Export_Form extends ACF_Admin_Tool{
         
         // validate
 		if($this->data === false)
-			return acf_add_admin_notice(__('No forms selected'), 'warning');
+			return acf_add_admin_notice(__('No forms selected', 'acfe'), 'warning');
         
         $keys = array();
         foreach($this->data as $key => $args){

--- a/includes/admin/tools/form-import.php
+++ b/includes/admin/tools/form-import.php
@@ -23,13 +23,13 @@ class ACFE_Admin_Tool_Import_Form extends ACF_Admin_Tool{
     function html(){
         
         ?>
-        <p><?php _e('Import Forms', 'acf'); ?></p>
+        <p><?php _e('Import Forms', 'acfe'); ?></p>
         
         <div class="acf-fields">
             <?php 
 			
 			acf_render_field_wrap(array(
-				'label'		=> __('Select File', 'acf'),
+				'label'		=> __('Select File', 'acfe'),
 				'type'		=> 'file',
 				'name'		=> 'acf_import_file',
 				'value'		=> false,
@@ -40,7 +40,7 @@ class ACFE_Admin_Tool_Import_Form extends ACF_Admin_Tool{
         </div>
         
         <p class="acf-submit">
-            <button type="submit" name="action" class="button button-primary"><?php _e('Import File'); ?></button>
+            <button type="submit" name="action" class="button button-primary"><?php _e('Import File', 'acfe'); ?></button>
         </p>
         <?php
         
@@ -50,18 +50,18 @@ class ACFE_Admin_Tool_Import_Form extends ACF_Admin_Tool{
         
         // Check file size.
 		if(empty($_FILES['acf_import_file']['size']))
-			return acf_add_admin_notice(__("No file selected", 'acf'), 'warning');
+			return acf_add_admin_notice(__("No file selected", 'acfe'), 'warning');
 		
 		// Get file data.
 		$file = $_FILES['acf_import_file'];
 		
 		// Check errors.
 		if($file['error'])
-			return acf_add_admin_notice(__("Error uploading file. Please try again", 'acf'), 'warning');
+			return acf_add_admin_notice(__("Error uploading file. Please try again", 'acfe'), 'warning');
 		
 		// Check file type.
 		if(pathinfo($file['name'], PATHINFO_EXTENSION) !== 'json')
-			return acf_add_admin_notice(__("Incorrect file type", 'acf'), 'warning');
+			return acf_add_admin_notice(__("Incorrect file type", 'acfe'), 'warning');
 		
 		// Read JSON.
 		$json = file_get_contents($file['tmp_name']);
@@ -69,7 +69,7 @@ class ACFE_Admin_Tool_Import_Form extends ACF_Admin_Tool{
 		
 		// Check if empty.
     	if(!$json || !is_array($json))
-    		return acf_add_admin_notice(__("Import file empty", 'acf'), 'warning');
+    		return acf_add_admin_notice(__("Import file empty", 'acfe'), 'warning');
     	
     	$ids = array();
     	
@@ -79,7 +79,7 @@ class ACFE_Admin_Tool_Import_Form extends ACF_Admin_Tool{
             // Check if already exists
             if(get_page_by_path($form_name, OBJECT, 'acfe-form')){
                 
-                acf_add_admin_notice(__("Form {$args['title']} already exists. Import aborted."), 'warning');
+                acf_add_admin_notice(__("Form {$args['title']} already exists. Import aborted.", 'acfe'), 'warning');
                 continue;
                 
             }
@@ -99,7 +99,7 @@ class ACFE_Admin_Tool_Import_Form extends ACF_Admin_Tool{
             // Insert error
             if(is_wp_error($post_id)){
                 
-                acf_add_admin_notice(__("Something went wrong with the form {$title}. Import aborted."), 'warning');
+                acf_add_admin_notice(__("Something went wrong with the form {$title}. Import aborted.", 'acfe'), 'warning');
                 continue;
                 
             }
@@ -122,7 +122,7 @@ class ACFE_Admin_Tool_Import_Form extends ACF_Admin_Tool{
 		$total = count($ids);
 		
 		// Generate text
-		$text = sprintf(_n('1 form imported', '%s forms imported', $total, 'acf'), $total);		
+		$text = sprintf(_n('1 form imported', '%s forms imported', $total, 'acfe'), $total);		
 		
 		// Add links to text
 		$links = array();

--- a/includes/admin/views/html-options-edit.php
+++ b/includes/admin/views/html-options-edit.php
@@ -1,9 +1,9 @@
 <div class="wrap acf-settings-wrap">
     
     <?php
-    $title = __('Edit Option');
+    $title = __('Edit Option', 'acfe');
     if($_REQUEST['action'] === 'add')
-        $title = __('Add Option');
+        $title = __('Add Option', 'acfe');
     ?>
     <h1 class="wp-heading-inline"><?php echo $title; ?></h1>
     

--- a/includes/admin/views/html-options-list.php
+++ b/includes/admin/views/html-options-list.php
@@ -1,7 +1,7 @@
 <div class="wrap" id="acfe-admin-options">
 
     <h1 class="wp-heading-inline"><?php _e('Options'); ?></h1> <span style="padding: 4px 6px;border-radius: 2px;background: #555;color: #fff;position: relative;top: -3px;font-weight: 600;margin-left: 4px;">BETA</span> 
-    <a href="<?php echo sprintf('?page=%s&action=add', esc_attr($_REQUEST['page'])); ?>" class="page-title-action"><?php _e('Add New'); ?></a>
+    <a href="<?php echo sprintf('?page=%s&action=add', esc_attr($_REQUEST['page'])); ?>" class="page-title-action"><?php _e('Add New', 'acfe'); ?></a>
     
     <hr class="wp-header-end" />
     
@@ -20,7 +20,7 @@
                         // Prepare items
                         $acfe_options_list->prepare_items();
 
-                        $acfe_options_list->search_box('Search', 'search');
+                        $acfe_options_list->search_box(__('Search', 'acfe'), 'search');
 
                         $acfe_options_list->display();
                         

--- a/includes/core/helpers.php
+++ b/includes/core/helpers.php
@@ -371,7 +371,7 @@ function acfe_get_roles($user_roles = array()){
         global $wp_roles;
         
         if(is_multisite())
-            $user_roles['super_admin'] = __('Super Admin');
+            $user_roles['super_admin'] = __('Super Admin', 'acfe');
         
         foreach($wp_roles->roles as $role => $settings){
             

--- a/includes/field-groups/field-group-category.php
+++ b/includes/field-groups/field-group-category.php
@@ -38,7 +38,7 @@ function acfe_field_group_category_submenu(){
     if(!acf_get_setting('show_admin'))
         return;
     
-    add_submenu_page('edit.php?post_type=acf-field-group', __('Categories', 'acfe')), __('Categories', 'acfe')), acf_get_setting('capability'), 'edit-tags.php?taxonomy=acf-field-group-category');
+    add_submenu_page('edit.php?post_type=acf-field-group', __('Categories', 'acfe'), __('Categories', 'acfe'), acf_get_setting('capability'), 'edit-tags.php?taxonomy=acf-field-group-category');
     
 }
 
@@ -60,7 +60,7 @@ function acfe_field_group_category_column($columns){
     $new_columns = array();
     foreach($columns as $key => $value) {
         if($key === 'title')
-            $new_columns['acf-field-group-category'] = __('Categories', 'acfe'));
+            $new_columns['acf-field-group-category'] = __('Categories', 'acfe');
         
         $new_columns[$key] = $value;
     }

--- a/includes/field-groups/field-group-category.php
+++ b/includes/field-groups/field-group-category.php
@@ -16,8 +16,8 @@ function acfe_field_group_category_register(){
         'show_tagcloud'     => false,
         'rewrite'           => false,
         'labels'            => array(
-            'name'              => _x('Categories', 'Category'),
-            'singular_name'     => _x('Categories', 'Category'),
+            'name'              => _x('Categories', 'Category', 'acfe'),
+            'singular_name'     => _x('Categories', 'Category', 'acfe'),
             'search_items'      => __('Search categories', 'acfe'),
             'all_items'         => __('All categories', 'acfe'),
             'parent_item'       => __('Parent category', 'acfe'),
@@ -38,7 +38,7 @@ function acfe_field_group_category_submenu(){
     if(!acf_get_setting('show_admin'))
         return;
     
-    add_submenu_page('edit.php?post_type=acf-field-group', __('Categories'), __('Categories'), acf_get_setting('capability'), 'edit-tags.php?taxonomy=acf-field-group-category');
+    add_submenu_page('edit.php?post_type=acf-field-group', __('Categories', 'acfe')), __('Categories', 'acfe')), acf_get_setting('capability'), 'edit-tags.php?taxonomy=acf-field-group-category');
     
 }
 
@@ -60,7 +60,7 @@ function acfe_field_group_category_column($columns){
     $new_columns = array();
     foreach($columns as $key => $value) {
         if($key === 'title')
-            $new_columns['acf-field-group-category'] = __('Categories');
+            $new_columns['acf-field-group-category'] = __('Categories', 'acfe'));
         
         $new_columns[$key] = $value;
     }

--- a/includes/field-groups/field-group.php
+++ b/includes/field-groups/field-group.php
@@ -111,37 +111,37 @@ function acfe_field_group_meta_fix_repeater($field){
 add_action('acf/field_group/admin_head', 'acfe_render_field_group_settings');
 function acfe_render_field_group_settings(){
     
-    add_meta_box('acf-field-group-acfe', __('Field group', 'acf'), function(){
+    add_meta_box('acf-field-group-acfe', __('Field group', 'acfe'), function(){
         
         global $field_group;
         
         // Form settings
         acf_render_field_wrap(array(
-            'label'         => __('Advanced settings'),
+            'label'         => __('Advanced settings', 'acfe'),
             'name'          => 'acfe_form',
             'prefix'        => 'acf_field_group',
             'type'			=> 'true_false',
 			'ui'			=> 1,
-            'instructions'	=> __('Enable advanced fields settings & validation'),
+            'instructions'	=> __('Enable advanced fields settings & validation', 'acfe'),
             'value'         => (isset($field_group['acfe_form'])) ? $field_group['acfe_form'] : '',
             'required'      => false,
         ));
         
         // Meta
         acf_render_field_wrap(array(
-            'label'         => __('Custom meta data'),
+            'label'         => __('Custom meta data', 'acfe'),
             'name'          => 'acfe_meta',
             'key'           => 'acfe_meta',
-            'instructions'  => __('Add custom meta data to the field group. Can be retrived using <code>acf_get_field_group()</code>'),
+            'instructions'  => __('Add custom meta data to the field group. Can be retrived using <code>acf_get_field_group()</code>', 'acfe'),
             'prefix'        => 'acf_field_group',
             'type'          => 'repeater',
-            'button_label'  => __('+ Meta'),
+            'button_label'  => __('+ Meta', 'acfe'),
             'required'      => false,
             'layout'        => 'table',
             'value'         => (isset($field_group['acfe_meta'])) ? $field_group['acfe_meta'] : array(),
             'sub_fields'    => array(
                 array(
-                    'label'         => __('Key'),
+                    'label'         => __('Key', 'acfe'),
                     'name'          => 'acfe_meta_key',
                     'key'           => 'acfe_meta_key',
                     'prefix'        => '',
@@ -157,7 +157,7 @@ function acfe_render_field_group_settings(){
                     ),
                 ),
                 array(
-                    'label'         => __('Value'),
+                    'label'         => __('Value', 'acfe'),
                     'name'          => 'acfe_meta_value',
                     'key'           => 'acfe_meta_value',
                     'prefix'        => '',
@@ -178,8 +178,8 @@ function acfe_render_field_group_settings(){
         // Data
         
         acf_render_field_wrap(array(
-            'label'         => __('Field group data'),
-            'instructions'  => __('View raw field group data, for development use'),
+            'label'         => __('Field group data', 'acfe'),
+            'instructions'  => __('View raw field group data, for development use', 'acfe'),
             'type'          => 'acfe_dynamic_message',
             'name'          => 'acfe_data',
             'prefix'        => 'acf_field_group',
@@ -192,7 +192,7 @@ function acfe_render_field_group_settings(){
             'name'          => 'acfe_note',
             'prefix'        => 'acf_field_group',
             'type'          => 'textarea',
-            'instructions'	=> __('Add personal note. Only visible to administrators'),
+            'instructions'	=> __('Add personal note. Only visible to administrators', 'acfe'),
             'value'         => (isset($field_group['acfe_note'])) ? $field_group['acfe_note'] : '',
             'required'      => false,
         ));
@@ -279,8 +279,8 @@ function acfe_render_field_group_settings_side(){
         
         if(acfe_is_field_group_json_desync($field_group)){
             acf_render_field_wrap(array(
-                'label'         => __('Json Desync'),
-                'instructions'  => __('Local json file is different from this version. If you manually synchronize it, you will lose your current field group settings'),
+                'label'         => __('Json Desync', 'acfe'),
+                'instructions'  => __('Local json file is different from this version. If you manually synchronize it, you will lose your current field group settings', 'acfe'),
                 'type'          => 'acfe_dynamic_message',
                 'name'          => 'acfe_sync_available',
                 'prefix'        => 'acf_field_group',
@@ -325,7 +325,7 @@ function acfe_render_field_group_settings_side(){
         }
         
         acf_render_field_wrap(array(
-            'label'         => __('Auto Sync'),
+            'label'         => __('Auto Sync', 'acfe'),
             'instructions'  => '',
             'type'          => 'checkbox',
             'name'          => 'acfe_autosync',
@@ -338,11 +338,11 @@ function acfe_render_field_group_settings_side(){
         ));
         
         acf_render_field_wrap(array(
-            'label'         => __('Permissions'),
+            'label'         => __('Permissions', 'acfe'),
             'name'          => 'acfe_permissions',
             'prefix'        => 'acf_field_group',
             'type'          => 'checkbox',
-            'instructions'	=> __('Select user roles that are allowed to view and edit this field group in post edition'),
+            'instructions'	=> __('Select user roles that are allowed to view and edit this field group in post edition', 'acfe'),
             'required'      => false,
             'default_value' => false,
             'choices'       => acfe_get_roles(),
@@ -484,11 +484,11 @@ function acfe_render_field_group_data($field){
     
     $field_group = acf_get_field_group($field['value']);
     if(!$field_group){
-        echo '<a href="#" class="button disabled" disabled>' . __('Data') . '</a>';
+        echo '<a href="#" class="button disabled" disabled>' . __('Data', 'acfe') . '</a>';
         return;
     }
     
-    echo '<a href="#" class="button acfe_modal_open" data-modal-key="' . $field_group['key'] . '">' . __('Data') . '</a>';
+    echo '<a href="#" class="button acfe_modal_open" data-modal-key="' . $field_group['key'] . '">' . __('Data', 'acfe') . '</a>';
     echo '<div class="acfe-modal" data-modal-key="' . $field_group['key'] . '"><div style="padding:15px;"><pre>' . print_r($field_group, true) . '</pre></div></div>';
     
 }
@@ -572,7 +572,7 @@ function acfe_permissions_field_groups($field_groups){
 add_filter('acf/prepare_field/name=instruction_placement', 'acfe_field_group_instruction_placement');
 function acfe_field_group_instruction_placement($field){
     
-    $field['choices'] = array_merge($field['choices'], array('acfe_instructions_tooltip' => 'Tooltip'));
+    $field['choices'] = array_merge($field['choices'], array('acfe_instructions_tooltip' => __('Tooltip', 'acfe')));
     
     return $field;
     

--- a/includes/field-groups/field-groups.php
+++ b/includes/field-groups/field-groups.php
@@ -33,18 +33,18 @@ add_filter('manage_edit-acf-field-group_columns', 'acfe_field_groups_column', 99
 function acfe_field_groups_column($columns){
     
     // Locations
-    $columns['acfe-locations'] = __('Locations');
+    $columns['acfe-locations'] = __('Locations', 'acfe');
     
     // Load
-    $columns['acfe-local'] = __('Load');
+    $columns['acfe-local'] = __('Load', 'acfe');
     
     // PHP sync
     if(acf_get_setting('acfe/php'))
-        $columns['acfe-autosync-php'] = __('PHP sync');
+        $columns['acfe-autosync-php'] = __('PHP sync', 'acfe');
     
     // Json sync
     if(acf_get_setting('json'))
-        $columns['acfe-autosync-json'] = __('Json sync');
+        $columns['acfe-autosync-json'] = __('Json sync', 'acfe');
     
     // Fix 'Sync' screen columns
     if(acf_maybe_get_GET('post_status') === 'sync'){
@@ -66,11 +66,11 @@ function acfe_field_groups_column($columns){
     elseif(acf_maybe_get_GET('post_status') === 'acfe-third-party'){
         
         $columns = array(
-            'title'             => __('Title', 'acf'),
-            'acfe-source'       => __('Source', 'acf'),
-            'acf-fg-count'      => __('Fields', 'acf'),
-            'acfe-locations'    => __('Locations', 'acf'),
-            'acfe-local'        => __('Load', 'acf'),
+            'title'             => __('Title', 'acfe'),
+            'acfe-source'       => __('Source', 'acfe'),
+            'acf-fg-count'      => __('Fields', 'acfe'),
+            'acfe-locations'    => __('Locations', 'acfe'),
+            'acfe-local'        => __('Load', 'acfe'),
         );
         
     }
@@ -129,7 +129,7 @@ function acfe_field_groups_column_html($column, $post_id){
         
         else{
             
-            $source = '<span style="color:#aaa;">' . __('Unknown', 'acf') . '</span>';
+            $source = '<span style="color:#aaa;">' . __('Unknown', 'acfe') . '</span>';
             
         }
         
@@ -292,7 +292,7 @@ function acfe_field_groups_column_html($column, $post_id){
         
         elseif($local_field_group_type === 'json'){
             
-            echo '<span class="acf-js-tooltip" title="' . $field_group['key'] . ' is registered locally">json</span>';
+            echo '<span class="acf-js-tooltip" title="' . $field_group['key'] . __(' is registered locally', 'acfe') . '">json</span>';
             
             return;
             
@@ -300,7 +300,7 @@ function acfe_field_groups_column_html($column, $post_id){
         
         else{
         
-            echo '<span class="acf-js-tooltip" title="' . $field_group['key'] . ' is not registered locally">DB</span>';
+            echo '<span class="acf-js-tooltip" title="' . $field_group['key'] . __(' is not registered locally', 'acfe') . '">DB</span>';
             
             return;
             
@@ -332,14 +332,14 @@ function acfe_field_groups_column_html($column, $post_id){
             
             echo '<span style="color:#ccc" class="dashicons dashicons-yes"></span>';
             
-            echo '<span style="color:#ccc;font-size:16px;vertical-align:text-top;" class="acf-js-tooltip dashicons dashicons-warning" title="Folder \'/acfe-php\' was not found in your theme.<br />You must create it to activate this setting"></span>';
+            echo '<span style="color:#ccc;font-size:16px;vertical-align:text-top;" class="acf-js-tooltip dashicons dashicons-warning" title="' .  __('Folder \'/acfe-php\' was not found in your theme.<br />You must create it to activate this setting', 'acfe') . '"></span>';
             
         }
         
         elseif(!acfe_has_field_group_autosync_file($field_group, 'php')){
             
             echo '<span style="color:#ccc" class="dashicons dashicons-yes"></span>';
-            echo '<span style="color:#ccc;font-size:16px;vertical-align:text-top;" class="acf-js-tooltip dashicons dashicons-warning" title="Local file ' . $field_group['key'] . '.php will be created upon update"></span>';
+            echo '<span style="color:#ccc;font-size:16px;vertical-align:text-top;" class="acf-js-tooltip dashicons dashicons-warning" title="Local file ' . $field_group['key'] .  __('.php will be created upon update', 'acfe') . '"></span>';
             
         }
         

--- a/includes/fields-settings/bidirectional.php
+++ b/includes/fields-settings/bidirectional.php
@@ -14,10 +14,10 @@ function acfe_bidirectional_settings($field){
     
     // Settings
     acf_render_field_setting($field, array(
-        'label'             => __('Bidirectional'),
+        'label'             => __('Bidirectional', 'acfe'),
         'key'               => 'acfe_bidirectional',
         'name'              => 'acfe_bidirectional',
-        'instructions'      => __('Set the field as bidirectional'),
+        'instructions'      => __('Set the field as bidirectional', 'acfe'),
         'type'              => 'group',
         'required'          => false,
         'conditional_logic' => false,

--- a/includes/fields-settings/data.php
+++ b/includes/fields-settings/data.php
@@ -40,18 +40,18 @@ function acfe_render_field_data($field){
     $get_field_debug = '<pre style="margin-bottom:15px;">' . print_r($get_field, true) . '</pre>';
 
     if(!$get_field)
-        $get_field_debug = '<pre>Field data unavailable</pre>';
+        $get_field_debug = '<pre>' . __('Field data unavailable', 'acfe') . '</pre>';
 
     $get_post = get_post($acfe_field_data_id);
     $get_post_debug = '<pre>' . print_r($get_post, true) . '</pre>';
     
     if(!$get_post || $get_post->post_type !== 'acf-field'){
-        $get_post_debug = '<pre>Post object unavailable</pre>';
+        $get_post_debug = '<pre>' . __('Post object unavailable', 'acfe') . '</pre>';
     }
     
     $button = '<a href="#" class="button acfe_modal_open" style="margin-left:5px;" data-modal-key="' . $acfe_field_data_id . '">' . __('Data') . '</a>';
     if(!$get_field && !$get_post)
-        $button = '<a href="#" class="button disabled" disabled>' . __('Data') . '</a>';
+        $button = '<a href="#" class="button disabled" disabled>' . __('Data', 'acfe') . '</a>';
     
     echo $button . '<div class="acfe-modal" data-modal-key="' . $acfe_field_data_id . '"><div style="padding:15px;">' . $get_field_debug . $get_post_debug . '</div></div>';
     

--- a/includes/fields-settings/permissions.php
+++ b/includes/fields-settings/permissions.php
@@ -11,7 +11,7 @@ function acfe_permissions_settings($field){
         'label'         => __('Permissions'),
         'name'          => 'acfe_permissions',
         'key'           => 'acfe_permissions',
-        'instructions'  => __('Select user roles that are allowed to view and edit this field. If nothing is selected, then this field will be available to everyone.'),
+        'instructions'  => __('Select user roles that are allowed to view and edit this field. If nothing is selected, then this field will be available to everyone.', 'acfe'),
         'type'          => 'checkbox',
         'required'      => false,
         'default_value' => false,

--- a/includes/fields-settings/settings.php
+++ b/includes/fields-settings/settings.php
@@ -109,17 +109,17 @@ class acfe_field_settings{
         
         // Settings
         acf_render_field_setting($field, array(
-            'label'         => __('Advanced settings', 'acf'),
+            'label'         => __('Advanced settings', 'acfe'),
             'name'          => 'acfe_settings',
             'key'           => 'acfe_settings',
-            'instructions'  => __('Change field settings based on location'),
+            'instructions'  => __('Change field settings based on location', 'acfe'),
             'type'          => 'repeater',
-            'button_label'  => __('Add settings'),
+            'button_label'  => __('Add settings', 'acfe'),
             'required'      => false,
             'layout'        => 'row',
             'sub_fields'    => array(
                 array(
-                    'label'             => 'Location',
+                    'label'             => __('Location', 'acfe'),
                     'name'              => 'acfe_settings_location',
                     'key'               => 'acfe_settings_location',
                     'type'              => 'select',
@@ -132,28 +132,28 @@ class acfe_field_settings{
                         'id'    => '',
                     ),
                     'choices'           => array(
-                        'admin' => 'Administration',
-                        'front' => 'Front-end',
+                        'admin' => __('Administration', 'acfe'),
+                        'front' => __('Front-end', 'acfe'),
                     ),
                     'allow_null'        => true,
                     'multiple'          => 0,
                     'ui'                => 0,
                     'return_format'     => 'value',
                     'ajax'              => 0,
-                    'placeholder'       => 'Everywhere',
+                    'placeholder'       => __('Everywhere', 'acfe'),
                 ),
                 array(
-                    'label'         => __('Settings'),
+                    'label'         => __('Settings', 'acfe'),
                     'name'          => 'acfe_settings_settings',
                     'key'           => 'acfe_settings_settings',
                     'instructions'  => '',
                     'type'          => 'repeater',
-                    'button_label'  => __('+'),
+                    'button_label'  => __('+', 'acfe'),
                     'required'      => false,
                     'layout'        => 'table',
                     'sub_fields'    => array(
                         array(
-                            'label'         => 'Setting',
+                            'label'         => __('Setting', 'acfe'),
                             'name'          => 'acfe_settings_setting_type',
                             'key'           => 'acfe_settings_setting_type',
                             'prefix'        => '',
@@ -168,17 +168,17 @@ class acfe_field_settings{
                                 'id'    => '',
                             ),
                             'choices'       => array(
-                                'required'      => 'Required',
-                                'hide_field'    => 'Hide field',
-                                'hide_label'    => 'Hide label',
-                                'default_value' => 'Default value',
-                                'placeholder'   => 'Placeholder',
-                                'instructions'  => 'Instructions',
-                                'custom'        => 'Custom setting',
+                                'required'      => __('Required', 'acfe'),
+                                'hide_field'    => __('Hide field', 'acfe'),
+                                'hide_label'    => __('Hide label', 'acfe'),
+                                'default_value' => __('Default value', 'acfe'),
+                                'placeholder'   => __('Placeholder', 'acfe'),
+                                'instructions'  => __('Instructions', 'acfe'),
+                                'custom'        => __('Custom setting', 'acfe'),
                             )
                         ),
                         array(
-                            'label'         => 'Setting name',
+                            'label'         => __('Setting name', 'acfe'),
                             'name'          => 'acfe_settings_setting_name',
                             'key'           => 'acfe_settings_setting_name',
                             'prefix'        => '',
@@ -203,7 +203,7 @@ class acfe_field_settings{
                             )
                         ),
                         array(
-                            'label'         => 'Operator / Value',
+                            'label'         => __('Operator / Value', 'acfe'),
                             'name'          => 'acfe_settings_setting_operator',
                             'key'           => 'acfe_settings_setting_operator',
                             'prefix'        => '',
@@ -229,7 +229,7 @@ class acfe_field_settings{
                             ),
                         ),
                         array(
-                            'label'         => 'Value',
+                            'label'         => __('Value', 'acfe'),
                             'name'          => 'acfe_settings_setting_value',
                             'key'           => 'acfe_settings_setting_value',
                             'prefix'        => '',

--- a/includes/fields-settings/validation.php
+++ b/includes/fields-settings/validation.php
@@ -168,7 +168,7 @@ class acfe_field_validation{
             'layout'        => 'row',
             'sub_fields'    => array(
                 array(
-                    'label'             => __('Location', 'acfe),
+                    'label'             => __('Location', 'acfe'),
                     'name'              => 'acfe_validate_location',
                     'key'               => 'acfe_validate_location',
                     'type'              => 'select',

--- a/includes/fields-settings/validation.php
+++ b/includes/fields-settings/validation.php
@@ -22,41 +22,41 @@ class acfe_field_validation{
         $this->functions = array(
         
             'General' => array(
-                'value'                 => 'If value',
-                'strlen'                => 'If value length - strlen(value)',
+                'value'                 => __('If value', 'acfe'),
+                'strlen'                => __('If value length - strlen(value)', 'acfe'),
             ),
             
             'Exists' => array(
-                'email_exists'          => 'If email exists - email_exists(value)',
-                'post_type_exists'      => 'If post type exists - post_type_exists(value)',
-                'taxonomy_exists'       => 'If taxonomy exists - taxonomy_exists(value)',
-                'term_exists'           => 'If term exists - term_exists(value)',
-                'username_exists'       => 'If username exists - username_exists(value)',
+                'email_exists'          => __('If email exists - email_exists(value)', 'acfe'),
+                'post_type_exists'      => __('If post type exists - post_type_exists(value)', 'acfe'),
+                'taxonomy_exists'       => __('If taxonomy exists - taxonomy_exists(value)', 'acfe'),
+                'term_exists'           => __('If term exists - term_exists(value)', 'acfe'),
+                'username_exists'       => __('If username exists - username_exists(value)', 'acfe'),
             ),
             
             'Is' => array(
-                'is_email'              => 'If is email - is_email(value))',
-                'is_user_logged_in'     => 'If is user logged in - is_user_logged_in()',
+                'is_email'              => __('If is email - is_email(value))', 'acfe'),
+                'is_user_logged_in'     => __('If is user logged in - is_user_logged_in()', 'acfe'),
             ),
             
             'Sanitize' => array(
-                'sanitize_email'        => 'If sanitize email - sanitize_email(value)',
-                'sanitize_file_name'    => 'If sanitize file name - sanitize_file_name(value)',
-                'sanitize_html_class'   => 'If sanitize html class - sanitize_html_class(value)',
-                'sanitize_key'          => 'If sanitize key - sanitize_key(value)',
-                'sanitize_meta'         => 'If sanitize meta - sanitize_meta(value)',
-                'sanitize_mime_type'    => 'If sanitize mime type - sanitize_mime_type(value)',
-                'sanitize_option'       => 'If sanitize option - sanitize_option(value)',
-                'sanitize_text_field'   => 'If sanitize text field - sanitize_text_field(value)',
-                'sanitize_title'        => 'If sanitize title - sanitize_title(value)',
-                'sanitize_user'         => 'If sanitize user - sanitize_user(value)',
+                'sanitize_email'        => __('If sanitize email - sanitize_email(value)', 'acfe'),
+                'sanitize_file_name'    => __('If sanitize file name - sanitize_file_name(value)', 'acfe'),
+                'sanitize_html_class'   => __('If sanitize html class - sanitize_html_class(value)', 'acfe'),
+                'sanitize_key'          => __('If sanitize key - sanitize_key(value)', 'acfe'),
+                'sanitize_meta'         => __('If sanitize meta - sanitize_meta(value)', 'acfe'),
+                'sanitize_mime_type'    => __('If sanitize mime type - sanitize_mime_type(value)', 'acfe'),
+                'sanitize_option'       => __('If sanitize option - sanitize_option(value)', 'acfe'),
+                'sanitize_text_field'   => __('If sanitize text field - sanitize_text_field(value)', 'acfe'),
+                'sanitize_title'        => __('If sanitize title - sanitize_title(value)', 'acfe'),
+                'sanitize_user'         => __('If sanitize user - sanitize_user(value)', 'acfe'),
             ),
             
             'User' => array(
-                'get_user_by_id'        => 'If get user by id - get_user_by(\'id\', value)',
-                'get_user_by_slug'      => 'If get user by slug - get_user_by(\'slug\', value)',
-                'get_user_by_email'     => 'If get user by email - get_user_by(\'email\', value)',
-                'get_user_by_login'     => 'If get user by login - get_user_by(\'login\', value)',
+                'get_user_by_id'        => __('If get user by id - get_user_by(\'id\', value)', 'acfe'),
+                'get_user_by_slug'      => __('If get user by slug - get_user_by(\'slug\', value)', 'acfe'),
+                'get_user_by_email'     => __('If get user by email - get_user_by(\'email\', value)', 'acfe'),
+                'get_user_by_login'     => __('If get user by login - get_user_by(\'login\', value)', 'acfe'),
             )
             
         );
@@ -158,17 +158,17 @@ class acfe_field_validation{
         
         // Settings
         acf_render_field_setting($field, array(
-            'label'         => __('Advanced validation'),
+            'label'         => __('Advanced validation', 'acfe'),
             'name'          => 'acfe_validate',
             'key'           => 'acfe_validate',
-            'instructions'  => __('Validate value against rules'),
+            'instructions'  => __('Validate value against rules', 'acfe'),
             'type'          => 'repeater',
-            'button_label'  => __('Add validation'),
+            'button_label'  => __('Add validation', 'acfe'),
             'required'      => false,
             'layout'        => 'row',
             'sub_fields'    => array(
                 array(
-                    'label'             => 'Location',
+                    'label'             => __('Location', 'acfe),
                     'name'              => 'acfe_validate_location',
                     'key'               => 'acfe_validate_location',
                     'type'              => 'select',
@@ -192,17 +192,17 @@ class acfe_field_validation{
                     'placeholder'       => 'Everywhere',
                 ),
                 array(
-                    'label'         => __('Rules'),
+                    'label'         => __('Rules', 'acfe'),
                     'name'          => 'acfe_validate_rules_and',
                     'key'           => 'acfe_validate_rules_and',
                     'instructions'  => '',
                     'type'          => 'repeater',
-                    'button_label'  => __('+ AND'),
+                    'button_label'  => __('+ AND', 'acfe'),
                     'required'      => false,
                     'layout'        => 'table',
                     'sub_fields'    => array(
                         array(
-                            'label'         => 'Function',
+                            'label'         => __('Function', 'acfe'),
                             'name'          => 'acfe_validate_function',
                             'key'           => 'acfe_validate_function',
                             'prefix'        => '',
@@ -234,12 +234,12 @@ class acfe_field_validation{
                                     '>='        => '>=',
                                     '<'         => '<',
                                     '<='        => '<=',
-                                    'contains'  => 'Contains',
-                                    '!contains'  => 'Doesn\'t contain',
-                                    'starts'    => 'Starts with',
-                                    '!starts'    => 'Doesn\'t start with',
-                                    'ends'      => 'Ends with',
-                                    '!ends'      => 'Doesn\'t end with',
+                                    'contains'  => __('Contains', 'acfe'),
+                                    '!contains'  => __('Doesn\'t contain', 'acfe'),
+                                    'starts'    => __('Starts with', 'acfe'),
+                                    '!starts'    => __('Doesn\'t start with', 'acfe'),
+                                    'ends'      => __('Ends with', 'acfe'),
+                                    '!ends'      => __('Doesn\'t end with', 'acfe'),
                                 ),
                                 'Values'     => array(
                                     'true'  => '== true',
@@ -363,7 +363,7 @@ class acfe_field_validation{
                     )
                 ),
                 array(
-                    'label'         => 'Error',
+                    'label'         => __('Error', 'acfe'),
                     'name'          => 'acfe_validate_error',
                     'key'           => 'acfe_validate_error',
                     'prefix'        => '',

--- a/includes/fields/field-advanced-link.php
+++ b/includes/fields/field-advanced-link.php
@@ -25,7 +25,7 @@ class acfe_field_advanced_link extends acf_field{
         
         // default_value
 		acf_render_field_setting($field, array(
-			'label'			=> __('Filter by Post Type','acf'),
+			'label'			=> __('Filter by Post Type','acfe'),
 			'instructions'	=> '',
 			'type'			=> 'select',
 			'name'			=> 'post_type',
@@ -33,12 +33,12 @@ class acfe_field_advanced_link extends acf_field{
 			'multiple'		=> 1,
 			'ui'			=> 1,
 			'allow_null'	=> 1,
-			'placeholder'	=> __("All post types",'acf'),
+			'placeholder'	=> __("All post types",'acfe'),
 		));
         
 		// default_value
 		acf_render_field_setting($field, array(
-			'label'			=> __('Filter by Taxonomy','acf'),
+			'label'			=> __('Filter by Taxonomy','acfe'),
 			'instructions'	=> '',
 			'type'			=> 'select',
 			'name'			=> 'taxonomy',
@@ -46,7 +46,7 @@ class acfe_field_advanced_link extends acf_field{
 			'multiple'		=> 1,
 			'ui'			=> 1,
 			'allow_null'	=> 1,
-			'placeholder'	=> __("All taxonomies",'acf'),
+			'placeholder'	=> __("All taxonomies",'acfe'),
 		));
         
         $field_name = 'field_name';
@@ -70,7 +70,7 @@ function my_acf_advanced_link_fields($fields, $field, $value){
         'prefix'    => $field['name'],
         'name'      => 'my_field',
         'key'       => 'acfe_advanced_link_my_field',
-        'label'     => 'My field',
+        'label'     => __('My field', 'acfe'), 
         'type'      => 'true_false',
         'ui'        => true,
         'value'     => isset($value['my_field']) ? $value['my_field'] : ''
@@ -86,7 +86,7 @@ function my_acf_advanced_link_fields($fields, $field, $value){
         
         // field_type
         acf_render_field_setting($field, array(
-            'label'			=> __('Instructions','acf'),
+            'label'			=> __('Instructions','acfe'),
             'instructions'	=> '',
             'type'			=> 'message',
             'name'			=> 'instructions',
@@ -186,14 +186,14 @@ function my_acf_advanced_link_fields($fields, $field, $value){
                 'prefix'	=> $field['name'],
                 'name'		=> 'type',
                 'key'		=> 'type',
-                'label'		=> __('Type', 'acf'),
+                'label'		=> __('Type', 'acfe'),
                 'type'		=> 'radio',
                 'value'		=> $link['type'],
                 'required'	=> false,
                 'class'     => 'input-type',
                 'choices'   => array(
-                    'url'   => __('URL', 'acf'),
-                    'post'  => __('Post', 'acf'),
+                    'url'   => __('URL', 'acfe'),
+                    'post'  => __('Post', 'acfe'),
                 ),
             ),
             
@@ -201,7 +201,7 @@ function my_acf_advanced_link_fields($fields, $field, $value){
                 'prefix'	=> $field['name'],
                 'name'		=> 'url',
                 'key'		=> 'url',
-                'label'		=> __('URL', 'acf'),
+                'label'		=> __('URL', 'acfe'),
                 'type'		=> 'text',
                 'value'		=> $link['url'],
                 'required'	=> false,
@@ -222,7 +222,7 @@ function my_acf_advanced_link_fields($fields, $field, $value){
                 'prefix'        => $field['name'],
                 'name'          => 'post',
                 'key'           => 'post',
-                'label'         => __('Post', 'acf'),
+                'label'         => __('Post', 'acfe'),
                 'type'          => 'post_object',
                 'value'         => $link['post'],
                 'required'      => false,
@@ -243,7 +243,7 @@ function my_acf_advanced_link_fields($fields, $field, $value){
                 'prefix'	=> $field['name'],
                 'name'		=> 'title',
                 'key'		=> 'title',
-                'label'		=> __('Link text', 'acf'),
+                'label'		=> __('Link text', 'acfe'),
                 'type'		=> 'text',
                 'value'		=> $link['title'],
                 'required'	=> false,
@@ -254,10 +254,10 @@ function my_acf_advanced_link_fields($fields, $field, $value){
                 'prefix'	=> $field['name'],
                 'name'		=> 'target',
                 'key'		=> 'target',
-                'label'		=> __('Target', 'acf'),
+                'label'		=> __('Target', 'acfe'),
                 'type'		=> 'true_false',
                 'value'		=> $link['target'],
-                'message'   => __('Open in an new window', 'acf'),
+                'message'   => __('Open in an new window', 'acfe'),
                 'required'	=> false,
                 'class'     => 'input-target',
             ),
@@ -292,8 +292,8 @@ function my_acf_advanced_link_fields($fields, $field, $value){
                 <span class="link-title"><?php echo esc_html($link['title']); ?></span>
                 <a class="link-url" href="<?php echo esc_url($link['url']); ?>" target="_blank"><?php echo esc_html($link['url_title']); ?></a>
                 <i class="acf-icon -link-ext acf-js-tooltip" title="<?php _e('Opens in a new window/tab', 'acf'); ?>"></i><?php
-                ?><a class="acf-icon -pencil -clear acf-js-tooltip" data-name="edit" href="#" title="<?php _e('Edit', 'acf'); ?>"></a><?php
-                ?><a class="acf-icon -cancel -clear acf-js-tooltip" data-name="remove" href="#" title="<?php _e('Remove', 'acf'); ?>"></a>
+                ?><a class="acf-icon -pencil -clear acf-js-tooltip" data-name="edit" href="#" title="<?php _e('Edit', 'acfe'); ?>"></a><?php
+                ?><a class="acf-icon -cancel -clear acf-js-tooltip" data-name="remove" href="#" title="<?php _e('Remove', 'acfe'); ?>"></a>
             </div>
             
         </div>

--- a/includes/fields/field-button.php
+++ b/includes/fields/field-button.php
@@ -52,11 +52,11 @@ class acfe_field_button extends acf_field{
         
         // class
         acf_render_field_setting($field, array(
-            'label'			=> __('Button attributes','acf'),
+            'label'			=> __('Button attributes','acfe'),
             'instructions'	=> '',
             'type'			=> 'text',
             'name'			=> 'button_class',
-            'prepend'		=> __('class', 'acf'),
+            'prepend'		=> __('class', 'acfe'),
         ));
         
         // id
@@ -65,7 +65,7 @@ class acfe_field_button extends acf_field{
             'instructions'	=> '',
             'type'			=> 'text',
             'name'			=> 'button_id',
-            'prepend'		=> __('id', 'acf'),
+            'prepend'		=> __('id', 'acfe'),
             '_append'       => 'button_class'
         ));
         
@@ -133,7 +133,7 @@ acf.addAction('acfe/fields/button/ajax_success', function(response, $el){
         
         // ajax instructions
         acf_render_field_setting($field, array(
-            'label'			=> __('Ajax instructions','acf'),
+            'label'			=> __('Ajax instructions','acfe'),
             'instructions'	=> '',
             'type'			=> 'message',
             'name'			=> 'instructions',

--- a/includes/fields/field-clone.php
+++ b/includes/fields/field-clone.php
@@ -7,10 +7,10 @@ add_action('acf/render_field_settings/type=clone', 'acfe_field_clone_settings');
 function acfe_field_clone_settings($field){
     
     acf_render_field_setting($field, array(
-        'label'         => __('Seemless Style'),
+        'label'         => __('Seemless Style', 'acfe'),
         'name'          => 'acfe_seemless_style',
         'key'           => 'acfe_seemless_style',
-        'instructions'  => __('Enable better CSS integration: remove borders and padding'),
+        'instructions'  => __('Enable better CSS integration: remove borders and padding', 'acfe'),
         'type'              => 'true_false',
         'message'           => '',
         'default_value'     => false,
@@ -32,10 +32,10 @@ function acfe_field_clone_settings($field){
     ));
     
     acf_render_field_setting($field, array(
-        'label'         => __('Edition modal'),
+        'label'         => __('Edition modal', 'acfe'),
         'name'          => 'acfe_clone_modal',
         'key'           => 'acfe_clone_modal',
-        'instructions'  => __('Edit fields in a modal'),
+        'instructions'  => __('Edit fields in a modal', 'acfe'),
         'type'              => 'true_false',
         'message'           => '',
         'default_value'     => false,
@@ -43,12 +43,12 @@ function acfe_field_clone_settings($field){
     ));
     
     acf_render_field_setting($field, array(
-        'label'         => __('Edition modal button'),
+        'label'         => __('Edition modal button', 'acfe'),
         'name'          => 'acfe_clone_modal_button',
         'key'           => 'acfe_clone_modal_button',
-        'instructions'  => __('Text displayed in the edition modal button'),
+        'instructions'  => __('Text displayed in the edition modal button', 'acfe'),
         'type'          => 'text',
-        'placeholder'   => __('Edit', 'acf'),
+        'placeholder'   => __('Edit', 'acfe'),
         'conditional_logic' => array(
             array(
                 array(
@@ -68,7 +68,7 @@ function acfe_field_clone_wrapper($wrapper, $field){
     if(acf_maybe_get($field, 'acfe_clone_modal')){
         
         $wrapper['data-acfe-clone-modal'] = 1;
-        $wrapper['data-acfe-clone-modal-button'] = __('Edit', 'acf');
+        $wrapper['data-acfe-clone-modal-button'] = __('Edit', 'acfe');
         
         if(acf_maybe_get($field, 'acfe_clone_modal_button')){
             

--- a/includes/fields/field-code-editor.php
+++ b/includes/fields/field-code-editor.php
@@ -54,39 +54,39 @@ class acfe_field_code_editor extends acf_field{
         
         // default_value
         acf_render_field_setting($field, array(
-            'label'			=> __('Default Value','acf'),
-            'instructions'	=> __('Appears when creating a new post','acf'),
+            'label'			=> __('Default Value','acfe'),
+            'instructions'	=> __('Appears when creating a new post','acfe'),
             'type'			=> 'acfe_code_editor',
             'name'			=> 'default_value',
         ));
         
         // placeholder
         acf_render_field_setting($field, array(
-            'label'			=> __('Placeholder','acf'),
-            'instructions'	=> __('Appears within the input','acf'),
+            'label'			=> __('Placeholder','acfe'),
+            'instructions'	=> __('Appears within the input','acfe'),
             'type'			=> 'acfe_code_editor',
             'name'			=> 'placeholder',
         ));
         
         // Mode
         acf_render_field_setting($field, array(
-            'label'			=> __('Editor mode','acf'),
-            'instructions'	=> __('Appears within the input','acf'),
+            'label'			=> __('Editor mode','acfe'),
+            'instructions'	=> __('Appears within the input','acfe'),
             'type'          => 'select',
             'name'			=> 'mode',
             'choices'       => array(
-                'text/html'                 => __('Text/HTML', 'acf'),
-                'javascript'                => __('JavaScript', 'acf'),
-                'css'                       => __('CSS', 'acf'),
-                'application/x-httpd-php'   => __('PHP (mixed)', 'acf'),
-                'text/x-php'                => __('PHP (plain)', 'acf'),
+                'text/html'                 => __('Text/HTML', 'acfe'),
+                'javascript'                => __('JavaScript', 'acfe'),
+                'css'                       => __('CSS', 'acfe'),
+                'application/x-httpd-php'   => __('PHP (mixed)', 'acfe'),
+                'text/x-php'                => __('PHP (plain)', 'acfe'),
             )
         ));
         
         // Lines
         acf_render_field_setting($field, array(
-            'label'			=> __('Show Lines', 'acf'),
-            'instructions'	=> 'Whether to show line numbers to the left of the editor',
+            'label'			=> __('Show Lines', 'acfe'),
+            'instructions'	=> __('Whether to show line numbers to the left of the editor', 'acfe'),
             'type'			=> 'true_false',
             'name'			=> 'lines',
             'ui'            => true,
@@ -94,8 +94,8 @@ class acfe_field_code_editor extends acf_field{
         
         // Indent Unit
         acf_render_field_setting($field, array(
-            'label'			=> __('Indent Unit', 'acf'),
-            'instructions'	=> 'How many spaces a block (whatever that means in the edited language) should be indented',
+            'label'			=> __('Indent Unit', 'acfe'),
+            'instructions'	=> __('How many spaces a block (whatever that means in the edited language) should be indented', 'acfe'),
             'type'			=> 'number',
             'min'			=> 0,
             'name'			=> 'indent_unit',
@@ -103,16 +103,16 @@ class acfe_field_code_editor extends acf_field{
         
         // maxlength
         acf_render_field_setting($field, array(
-            'label'			=> __('Character Limit','acf'),
-            'instructions'	=> __('Leave blank for no limit','acf'),
+            'label'			=> __('Character Limit','acfe'),
+            'instructions'	=> __('Leave blank for no limit','acfe'),
             'type'			=> 'number',
             'name'			=> 'maxlength',
         ));
         
         // rows
         acf_render_field_setting($field, array(
-            'label'			=> __('Rows','acf'),
-            'instructions'	=> __('Sets the textarea height','acf'),
+            'label'			=> __('Rows','acfe'),
+            'instructions'	=> __('Sets the textarea height','acfe'),
             'type'			=> 'number',
             'name'			=> 'rows',
             'placeholder'	=> 8

--- a/includes/fields/field-column.php
+++ b/includes/fields/field-column.php
@@ -52,8 +52,8 @@ class acfe_field_column extends acf_field{
         
         // endpoint
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Endpoint','acf'),
-			'instructions'	=> __('Define an endpoint for the previous tabs to stop. This will start a new group of columns.', 'acf'),
+			'label'			=> __('Endpoint','acfe'),
+			'instructions'	=> __('Define an endpoint for the previous tabs to stop. This will start a new group of columns.', 'acfe'),
 			'name'			=> 'endpoint',
 			'type'			=> 'true_false',
 			'ui'			=> 1,

--- a/includes/fields/field-dynamic-message.php
+++ b/includes/fields/field-dynamic-message.php
@@ -24,8 +24,8 @@ class acfe_field_dynamic_message extends acf_field{
             $field_name = $field['name'];
         
         ob_start();
-        ?>
-        Write your own PHP/HTML content using the following hook:<br /><br />
+        
+        echo __('Write your own PHP/HTML content using the following hook:', 'acfe') ?><br /><br />
 <pre>
 add_action('acf/render_field/name=<?php echo $field_name; ?>', 'my_acf_dynamic_message');
 function my_acf_dynamic_message(){
@@ -40,7 +40,7 @@ function my_acf_dynamic_message(){
         
         // field_type
         acf_render_field_setting($field, array(
-            'label'			=> __('Instructions','acf'),
+            'label'			=> __('Instructions','acfe'),
             'instructions'	=> '',
             'type'			=> 'message',
             'name'			=> 'instructions',

--- a/includes/fields/field-file.php
+++ b/includes/fields/field-file.php
@@ -20,10 +20,10 @@ add_action('acf/render_field_settings/type=file', 'acfe_field_file_settings', 0)
 function acfe_field_file_settings($field){
     
     acf_render_field_setting($field, array(
-        'label'         => __('Uploader type'),
+        'label'         => __('Uploader type', 'acfe'),
         'name'          => 'acfe_uploader',
         'key'           => 'acfe_uploader',
-        'instructions'  => __('Choose the uploader type'),
+        'instructions'  => __('Choose the uploader type', 'acfe'),
         'type'          => 'radio',
         'choices'       => array(
             'wp'    => 'Media',

--- a/includes/fields/field-flexible-content.php
+++ b/includes/fields/field-flexible-content.php
@@ -11,10 +11,10 @@ function acfe_flexible_settings($field){
     
     // Stylised button
     acf_render_field_setting($field, array(
-        'label'         => __('Stylised Button'),
+        'label'         => __('Stylised Button', 'acfe'),
         'name'          => 'acfe_flexible_stylised_button',
         'key'           => 'acfe_flexible_stylised_button',
-        'instructions'  => __('Better layouts button integration'),
+        'instructions'  => __('Better layouts button integration', 'acfe'),
         'type'              => 'true_false',
         'message'           => '',
         'default_value'     => false,
@@ -25,10 +25,10 @@ function acfe_flexible_settings($field){
     
     // Hide Empty Message
     acf_render_field_setting($field, array(
-        'label'         => __('Hide Empty Message'),
+        'label'         => __('Hide Empty Message', 'acfe'),
         'name'          => 'acfe_flexible_hide_empty_message',
         'key'           => 'acfe_flexible_hide_empty_message',
-        'instructions'  => __('Hide the empty message box'),
+        'instructions'  => __('Hide the empty message box', 'acfe'),
         'type'              => 'true_false',
         'message'           => '',
         'default_value'     => false,
@@ -48,12 +48,12 @@ function acfe_flexible_settings($field){
     
     // Empty Message
     acf_render_field_setting($field, array(
-        'label'         => __('Empty Message'),
+        'label'         => __('Empty Message', 'acfe'),
         'name'          => 'acfe_flexible_empty_message',
         'key'           => 'acfe_flexible_empty_message',
-        'instructions'  => __('Text displayed when the flexible field is empty'),
+        'instructions'  => __('Text displayed when the flexible field is empty', 'acfe'),
         'type'          => 'text',
-        'placeholder'   => __('Click the "Add Row" button below to start creating your layout'),
+        'placeholder'   => __('Click the "Add Row" button below to start creating your layout', 'acfe'),
         'conditional_logic' => array(
             array(
                 array(
@@ -72,10 +72,10 @@ function acfe_flexible_settings($field){
     
     // Layouts thumbnails
     acf_render_field_setting($field, array(
-        'label'         => __('Layouts: Thumbnails'),
+        'label'         => __('Layouts: Thumbnails', 'acfe'),
         'name'          => 'acfe_flexible_layouts_thumbnails',
         'key'           => 'acfe_flexible_layouts_thumbnails',
-        'instructions'  => __('Set a thumbnail for each layouts. You must save the field group to apply this setting'),
+        'instructions'  => __('Set a thumbnail for each layouts. You must save the field group to apply this setting', 'acfe'),
         'type'              => 'true_false',
         'message'           => '',
         'default_value'     => false,
@@ -86,10 +86,10 @@ function acfe_flexible_settings($field){
     
     // Layouts: Render
     acf_render_field_setting($field, array(
-        'label'         => __('Layouts: Render'),
+        'label'         => __('Layouts: Render', 'acfe'),
         'name'          => 'acfe_flexible_layouts_templates',
         'key'           => 'acfe_flexible_layouts_templates',
-        'instructions'  => __('Set template, style & javascript files for each layouts. This setting is mandatory in order to use <code style="font-size:11px;">get_flexible()</code> function. You must save the field group to apply this setting'),
+        'instructions'  => __('Set template, style & javascript files for each layouts. This setting is mandatory in order to use <code style="font-size:11px;">get_flexible()</code> function. You must save the field group to apply this setting', 'acfe'),
         'type'              => 'true_false',
         'message'           => '',
         'default_value'     => false,
@@ -100,10 +100,10 @@ function acfe_flexible_settings($field){
     
     // Layouts: Preview
     acf_render_field_setting($field, array(
-        'label'         => __('Layouts: Dynamic Preview'),
+        'label'         => __('Layouts: Dynamic Preview', 'acfe'),
         'name'          => 'acfe_flexible_layouts_previews',
         'key'           => 'acfe_flexible_layouts_previews',
-        'instructions'  => __('Use layouts render settings to display a dynamic preview in the post administration'),
+        'instructions'  => __('Use layouts render settings to display a dynamic preview in the post administration', 'acfe'),
         'type'              => 'true_false',
         'message'           => '',
         'default_value'     => false,
@@ -123,10 +123,10 @@ function acfe_flexible_settings($field){
     
     // Layouts: Placholder
     acf_render_field_setting($field, array(
-        'label'         => __('Layouts: Placeholder'),
+        'label'         => __('Layouts: Placeholder', 'acfe'),
         'name'          => 'acfe_flexible_layouts_placeholder',
         'key'           => 'acfe_flexible_layouts_placeholder',
-        'instructions'  => __('Display a placeholder with a pencil icon, making edition easier'),
+        'instructions'  => __('Display a placeholder with a pencil icon, making edition easier', 'acfe'),
         'type'              => 'true_false',
         'message'           => '',
         'default_value'     => false,
@@ -146,10 +146,10 @@ function acfe_flexible_settings($field){
     
     // Layouts: Close Button
     acf_render_field_setting($field, array(
-        'label'         => __('Layouts: Close Button'),
+        'label'         => __('Layouts: Close Button', 'acfe'),
         'name'          => 'acfe_flexible_close_button',
         'key'           => 'acfe_flexible_close_button',
-        'instructions'  => __('Display a close button to collapse the layout'),
+        'instructions'  => __('Display a close button to collapse the layout', 'acfe'),
         'type'              => 'true_false',
         'message'           => '',
         'default_value'     => false,
@@ -160,10 +160,10 @@ function acfe_flexible_settings($field){
     
     // Layouts: Title Edition
     acf_render_field_setting($field, array(
-        'label'         => __('Layouts: Title Edition'),
+        'label'         => __('Layouts: Title Edition', 'acfe'),
         'name'          => 'acfe_flexible_title_edition',
         'key'           => 'acfe_flexible_title_edition',
-        'instructions'  => __('Allow layout title edition'),
+        'instructions'  => __('Allow layout title edition', 'acfe'),
         'type'              => 'true_false',
         'message'           => '',
         'default_value'     => false,
@@ -174,10 +174,10 @@ function acfe_flexible_settings($field){
     
     // Layouts: Copy/Paste
     acf_render_field_setting($field, array(
-        'label'         => __('Layouts: Copy/Paste'),
+        'label'         => __('Layouts: Copy/Paste', 'acfe'),
         'name'          => 'acfe_flexible_copy_paste',
         'key'           => 'acfe_flexible_copy_paste',
-        'instructions'  => __('Allow copy/paste layouts functions'),
+        'instructions'  => __('Allow copy/paste layouts functions', 'acfe'),
         'type'              => 'true_false',
         'message'           => '',
         'default_value'     => false,
@@ -188,10 +188,10 @@ function acfe_flexible_settings($field){
     
     // Modal: Edition
     acf_render_field_setting($field, array(
-        'label'         => __('Layouts Modal: Edition'),
+        'label'         => __('Layouts Modal: Edition', 'acfe'),
         'name'          => 'acfe_flexible_modal_edition',
         'key'           => 'acfe_flexible_modal_edition',
-        'instructions'  => __('Edit layout content in a modal'),
+        'instructions'  => __('Edit layout content in a modal', 'acfe'),
         'type'              => 'true_false',
         'message'           => '',
         'default_value'     => false,
@@ -202,10 +202,10 @@ function acfe_flexible_settings($field){
     
     // Modal: Selection
     acf_render_field_setting($field, array(
-        'label'         => __('Layouts Modal: Selection'),
+        'label'         => __('Layouts Modal: Selection', 'acfe'),
         'name'          => 'acfe_flexible_modal',
         'key'           => 'acfe_flexible_modal',
-        'instructions'  => __('Select layouts in a modal'),
+        'instructions'  => __('Select layouts in a modal', 'acfe'),
         'type'          => 'group',
         'layout'        => 'block',
         'sub_fields'    => array(
@@ -233,8 +233,8 @@ function acfe_flexible_settings($field){
                 'name'          => 'acfe_flexible_modal_title',
                 'key'           => 'acfe_flexible_modal_title',
                 'type'          => 'text',
-                'prepend'       => __('Modal Title'),
-                'placeholder'   => 'Add Row',
+                'prepend'       => __('Modal Title', 'acfe'),
+                'placeholder'   => __('Add Row', 'acfe'),
                 'instructions'  => false,
                 'required'      => false,
                 'wrapper'       => array(
@@ -289,7 +289,7 @@ function acfe_flexible_settings($field){
                 'name'          => 'acfe_flexible_modal_categories',
                 'key'           => 'acfe_flexible_modal_categories',
                 'type'          => 'true_false',
-                'message'       => __('Categories'),
+                'message'       => __('Categories', 'acfe'),
                 'instructions'  => false,
                 'required'      => false,
                 'wrapper'       => array(
@@ -312,10 +312,10 @@ function acfe_flexible_settings($field){
     
     // Layouts: Force State
     acf_render_field_setting($field, array(
-        'label'         => __('Layouts: Force State'),
+        'label'         => __('Layouts: Force State', 'acfe'),
         'name'          => 'acfe_flexible_layouts_state',
         'key'           => 'acfe_flexible_layouts_state',
-        'instructions'  => __('Force layouts to be collapsed or opened'),
+        'instructions'  => __('Force layouts to be collapsed or opened', 'acfe'),
         'type'          => 'select',
         'allow_null'    => true,
         'choices'       => array(
@@ -335,10 +335,10 @@ function acfe_flexible_settings($field){
     
     // Layouts: Remove Collapse
     acf_render_field_setting($field, array(
-        'label'         => __('Layouts: Remove Collapse'),
+        'label'         => __('Layouts: Remove Collapse', 'acfe'),
         'name'          => 'acfe_flexible_layouts_remove_collapse',
         'key'           => 'acfe_flexible_layouts_remove_collapse',
-        'instructions'  => __('Remove collapse action'),
+        'instructions'  => __('Remove collapse action', 'acfe'),
         'type'              => 'true_false',
         'message'           => '',
         'default_value'     => false,
@@ -372,7 +372,7 @@ function acfe_flexible_layouts_settings_before($field){
     echo '</li>';
     
     acf_render_field_wrap(array(
-        'label' => __('Settings'),
+        'label' => __('Settings', 'acfe'),
         'type'  => 'hidden',
         'name'  => 'acfe_flexible_settings_label'
     ), 'ul');
@@ -409,13 +409,13 @@ function acfe_flexible_layouts_settings($field){
         $acfe_flexible_category = isset($layout['acfe_flexible_category']) ? $layout['acfe_flexible_category'] : '';
 
         acf_render_field_wrap(array(
-            'prepend'       => __('Category'),
+            'prepend'       => __('Category', 'acfe'),
             'name'          => 'acfe_flexible_category',
             'type'          => 'text',
             'class'         => 'acf-fc-meta-name',
             'prefix'        => $layout_prefix,
             'value'         => $acfe_flexible_category,
-            'placeholder'   => __('Multiple categories can be set using "|"')
+            'placeholder'   => __('Multiple categories can be set using "|"', 'acfe'), 
             
             /*
             'conditional_logic' => array(
@@ -444,7 +444,7 @@ function acfe_flexible_layouts_settings($field){
         $acfe_flexible_render_template = isset($layout['acfe_flexible_render_template']) ? $layout['acfe_flexible_render_template'] : '';
         
         acf_render_field_wrap(array(
-            'label'         => __('Render'),
+            'label'         => __('Render', 'acfe'),
             'prepend'       => str_replace(home_url(), '', ACFE_THEME_URL) . '/',
             'name'          => 'acfe_flexible_render_template',
             'type'          => 'text',
@@ -525,7 +525,7 @@ function acfe_flexible_layouts_settings($field){
         $acfe_flexible_thumbnail = isset($layout['acfe_flexible_thumbnail']) ? $layout['acfe_flexible_thumbnail'] : '';
         
         acf_render_field_wrap(array(
-            'label'         => __('Thumbnail'),
+            'label'         => __('Thumbnail', 'acfe'),
             'name'          => 'acfe_flexible_thumbnail',
             'type'          => 'image',
             'class'         => '',

--- a/includes/fields/field-forms.php
+++ b/includes/fields/field-forms.php
@@ -50,7 +50,7 @@ class acfe_field_forms extends acf_field{
         
         // Allow Form
 		acf_render_field_setting($field, array(
-			'label'			=> __('Allow Forms','acf'),
+			'label'			=> __('Allow Forms','acfe'),
 			'instructions'	=> '',
 			'type'			=> 'select',
 			'name'			=> 'forms',
@@ -58,7 +58,7 @@ class acfe_field_forms extends acf_field{
 			'multiple'		=> 1,
 			'ui'			=> 1,
 			'allow_null'	=> 1,
-			'placeholder'	=> __("All forms",'acf'),
+			'placeholder'	=> __("All forms",'acfe'),
 		));
         
         // field_type
@@ -69,23 +69,23 @@ class acfe_field_forms extends acf_field{
             'name'			=> 'field_type',
             'optgroup'		=> true,
             'choices'		=> array(
-                'checkbox'  => __('Checkbox', 'acf'),
-                'radio'     => __('Radio Buttons', 'acf'),
-                'select'    => _x('Select', 'noun', 'acf')
+                'checkbox'  => __('Checkbox', 'acfe'),
+                'radio'     => __('Radio Buttons', 'acfe'),
+                'select'    => _x('Select', 'noun', 'acfe')
             )
         ));
         
         // default_value
 		acf_render_field_setting($field, array(
-			'label'			=> __('Default Value','acf'),
-			'instructions'	=> __('Enter each default value on a new line','acf'),
+			'label'			=> __('Default Value','acfe'),
+			'instructions'	=> __('Enter each default value on a new line','acfe'),
 			'name'			=> 'default_value',
 			'type'			=> 'textarea',
 		));
         
         // return_format
         acf_render_field_setting($field, array(
-            'label'			=> __('Return Value', 'acf'),
+            'label'			=> __('Return Value', 'acfe'),
             'instructions'	=> '',
             'type'			=> 'radio',
             'name'			=> 'return_format',
@@ -98,7 +98,7 @@ class acfe_field_forms extends acf_field{
         
 		// Select + Radio: allow_null
 		acf_render_field_setting($field, array(
-			'label'			=> __('Allow Null?','acf'),
+			'label'			=> __('Allow Null?','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'allow_null',
 			'type'			=> 'true_false',
@@ -123,11 +123,11 @@ class acfe_field_forms extends acf_field{
         
         // placeholder
         acf_render_field_setting($field, array(
-            'label'			=> __('Placeholder Text','acf'),
-            'instructions'	=> __('Appears within the input','acf'),
+            'label'			=> __('Placeholder Text','acfe'),
+            'instructions'	=> __('Appears within the input','acfe'),
             'type'			=> 'text',
             'name'			=> 'placeholder',
-            'placeholder'   => _x('Select', 'verb', 'acf'),
+            'placeholder'   => _x('Select', 'verb', 'acfe'),
             'conditional_logic' => array(
                 array(
                     array(
@@ -160,7 +160,7 @@ class acfe_field_forms extends acf_field{
         
         // Select: multiple
 		acf_render_field_setting($field, array(
-			'label'			=> __('Select multiple values?','acf'),
+			'label'			=> __('Select multiple values?','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'multiple',
 			'type'			=> 'true_false',
@@ -178,7 +178,7 @@ class acfe_field_forms extends acf_field{
         
         // Select: ui
 		acf_render_field_setting($field, array(
-			'label'			=> __('Stylised UI','acf'),
+			'label'			=> __('Stylised UI','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'ui',
 			'type'			=> 'true_false',
@@ -197,7 +197,7 @@ class acfe_field_forms extends acf_field{
 		
 		// Select: ajax
 		acf_render_field_setting($field, array(
-			'label'			=> __('Use AJAX to lazy load choices?','acf'),
+			'label'			=> __('Use AJAX to lazy load choices?','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'ajax',
 			'type'			=> 'true_false',
@@ -220,12 +220,12 @@ class acfe_field_forms extends acf_field{
 		
 		// Radio: other_choice
 		acf_render_field_setting($field, array(
-			'label'			=> __('Other','acf'),
+			'label'			=> __('Other','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'other_choice',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Add 'other' choice to allow for custom values", 'acf'),
+			'message'		=> __("Add 'other' choice to allow for custom values", 'acfe'),
             'conditions' => array(
                 array(
                     array(
@@ -240,12 +240,12 @@ class acfe_field_forms extends acf_field{
 		
 		// Radio: save_other_choice
 		acf_render_field_setting($field, array(
-			'label'			=> __('Save Other','acf'),
+			'label'			=> __('Save Other','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'save_other_choice',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Save 'other' values to the field's choices", 'acf'),
+			'message'		=> __("Save 'other' values to the field's choices", 'acfe'),
             'conditions' => array(
                 array(
                     array(
@@ -264,14 +264,14 @@ class acfe_field_forms extends acf_field{
         
         // Checkbox: layout
 		acf_render_field_setting($field, array(
-			'label'			=> __('Layout','acf'),
+			'label'			=> __('Layout','acfe'),
 			'instructions'	=> '',
 			'type'			=> 'radio',
 			'name'			=> 'layout',
 			'layout'		=> 'horizontal', 
 			'choices'		=> array(
-				'vertical'		=> __("Vertical",'acf'), 
-				'horizontal'	=> __("Horizontal",'acf')
+				'vertical'		=> __("Vertical",'acfe'), 
+				'horizontal'	=> __("Horizontal",'acfe')
 			),
             'conditions' => array(
                 array(
@@ -293,8 +293,8 @@ class acfe_field_forms extends acf_field{
         
         // Checkbox: toggle
         acf_render_field_setting($field, array(
-			'label'			=> __('Toggle','acf'),
-			'instructions'	=> __('Prepend an extra checkbox to toggle all choices','acf'),
+			'label'			=> __('Toggle','acfe'),
+			'instructions'	=> __('Prepend an extra checkbox to toggle all choices','acfe'),
 			'name'			=> 'toggle',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
@@ -311,12 +311,12 @@ class acfe_field_forms extends acf_field{
         
         // Checkbox: other_choice
 		acf_render_field_setting($field, array(
-			'label'			=> __('Allow Custom','acf'),
+			'label'			=> __('Allow Custom','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'allow_custom',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Allow 'custom' values to be added", 'acf'),
+			'message'		=> __("Allow 'custom' values to be added", 'acfe'),
             'conditions' => array(
                 array(
                     array(
@@ -331,12 +331,12 @@ class acfe_field_forms extends acf_field{
 		
 		// Checkbox: save_other_choice
 		acf_render_field_setting($field, array(
-			'label'			=> __('Save Custom','acf'),
+			'label'			=> __('Save Custom','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'save_custom',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Save 'custom' values to the field's choices", 'acf'),
+			'message'		=> __("Save 'custom' values to the field's choices", 'acfe'),
             'conditions' => array(
                 array(
                     array(

--- a/includes/fields/field-group.php
+++ b/includes/fields/field-group.php
@@ -7,10 +7,10 @@ add_action('acf/render_field_settings/type=group', 'acfe_field_group_settings');
 function acfe_field_group_settings($field){
     
     acf_render_field_setting($field, array(
-        'label'         => __('Seemless Style'),
+        'label'         => __('Seemless Style', 'acfe'),
         'name'          => 'acfe_seemless_style',
         'key'           => 'acfe_seemless_style',
-        'instructions'  => __('Enable better CSS integration: remove borders and padding'),
+        'instructions'  => __('Enable better CSS integration: remove borders and padding', 'acfe'),
         'type'              => 'true_false',
         'message'           => '',
         'default_value'     => false,
@@ -27,10 +27,10 @@ function acfe_field_group_settings($field){
     ));
     
     acf_render_field_setting($field, array(
-        'label'         => __('Edition modal'),
+        'label'         => __('Edition modal', 'acfe'),
         'name'          => 'acfe_group_modal',
         'key'           => 'acfe_group_modal',
-        'instructions'  => __('Edit fields in a modal'),
+        'instructions'  => __('Edit fields in a modal', 'acfe'),
         'type'              => 'true_false',
         'message'           => '',
         'default_value'     => false,
@@ -47,12 +47,12 @@ function acfe_field_group_settings($field){
     ));
     
     acf_render_field_setting($field, array(
-        'label'         => __('Edition modal button'),
+        'label'         => __('Edition modal button', 'acfe'),
         'name'          => 'acfe_group_modal_button',
         'key'           => 'acfe_group_modal_button',
-        'instructions'  => __('Text displayed in the edition modal button'),
+        'instructions'  => __('Text displayed in the edition modal button', 'acfe'),
         'type'          => 'text',
-        'placeholder'   => __('Edit', 'acf'),
+        'placeholder'   => __('Edit', 'acfe'),
         'conditional_logic' => array(
             array(
                 array(
@@ -77,7 +77,7 @@ function acfe_field_group_wrapper($wrapper, $field){
     if(isset($field['acfe_group_modal']) && !empty($field['acfe_group_modal'])){
         
         $wrapper['data-acfe-group-modal'] = 1;
-        $wrapper['data-acfe-group-modal-button'] = __('Edit', 'acf');
+        $wrapper['data-acfe-group-modal-button'] = __('Edit', 'acfe');
         
         if(isset($field['acfe_group_modal_button']) && !empty($field['acfe_group_modal_button'])){
             

--- a/includes/fields/field-hidden.php
+++ b/includes/fields/field-hidden.php
@@ -39,8 +39,8 @@ class acfe_field_hidden extends acf_field{
         
         // default_value
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Value','acf'),
-			'instructions'	=> __('Default value in the hidden input','acf'),
+			'label'			=> __('Value','acfe'),
+			'instructions'	=> __('Default value in the hidden input','acfe'),
 			'type'			=> 'text',
 			'name'			=> 'default_value',
 		));

--- a/includes/fields/field-image.php
+++ b/includes/fields/field-image.php
@@ -20,10 +20,10 @@ add_action('acf/render_field_settings/type=image', 'acfe_field_image_settings', 
 function acfe_field_image_settings($field){
     
     acf_render_field_setting($field, array(
-        'label'         => __('Uploader type'),
+        'label'         => __('Uploader type', 'acfe'),
         'name'          => 'acfe_uploader',
         'key'           => 'acfe_uploader',
-        'instructions'  => __('Choose the uploader type'),
+        'instructions'  => __('Choose the uploader type', 'acfe'),
         'type'          => 'radio',
         'choices'       => array(
             'wp'    => 'Media',
@@ -38,10 +38,10 @@ function acfe_field_image_settings($field){
     ));
     
     acf_render_field_setting($field, array(
-        'label'         => __('Featured thumbnail'),
+        'label'         => __('Featured thumbnail', 'acfe'),
         'name'          => 'acfe_thumbnail',
         'key'           => 'acfe_thumbnail',
-        'instructions'  => __('Make this image the featured thumbnail'),
+        'instructions'  => __('Make this image the featured thumbnail', 'acfe'),
         'type'          => 'true_false',
         'default_value'     => false,
         'ui'                => true,

--- a/includes/fields/field-post-object.php
+++ b/includes/fields/field-post-object.php
@@ -8,22 +8,22 @@ function acfe_field_post_object_settings($field){
     
     // other_choice
     acf_render_field_setting($field, array(
-        'label'         => __('Allow Custom','acf'),
+        'label'         => __('Allow Custom','acfe'),
         'instructions'  => '',
         'name'          => 'allow_custom',
         'type'          => 'true_false',
         'ui'            => 1,
-        'message'       => __("Allow 'custom' values to be added", 'acf'),
+        'message'       => __("Allow 'custom' values to be added", 'acfe'),
     ));
     
     // save other_choice
     acf_render_field_setting($field, array(
-        'label'			=> __('Save Custom','acf'),
+        'label'			=> __('Save Custom','acfe'),
         'instructions'	=> '',
         'name'			=> 'save_custom',
         'type'			=> 'true_false',
         'ui'			=> 1,
-        'message'		=> __("Save 'custom' values as new post", 'acf'),
+        'message'		=> __("Save 'custom' values as new post", 'acfe'),
         'conditions'	=> array(
             'field'		=> 'allow_custom',
             'operator'	=> '==',
@@ -33,7 +33,7 @@ function acfe_field_post_object_settings($field){
     
     // save post_type
     acf_render_field_setting($field, array(
-        'label'			=> __('New Post Arguments','acf'),
+        'label'			=> __('New Post Arguments','acfe'),
         'instructions'	=> '',
         'name'			=> 'save_post_type',
         'type'			=> 'acfe_post_types',

--- a/includes/fields/field-post-statuses.php
+++ b/includes/fields/field-post-statuses.php
@@ -50,7 +50,7 @@ class acfe_field_post_statuses extends acf_field{
         
         // Allow Post Status
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Allow Post Status','acf'),
+			'label'			=> __('Allow Post Status','acfe'),
 			'instructions'	=> '',
 			'type'			=> 'select',
 			'name'			=> 'post_status',
@@ -58,34 +58,34 @@ class acfe_field_post_statuses extends acf_field{
 			'multiple'		=> 1,
 			'ui'			=> 1,
 			'allow_null'	=> 1,
-			'placeholder'	=> __("All post statuses",'acf'),
+			'placeholder'	=> __("All post statuses",'acfe'),
 		));
         
         // field_type
         acf_render_field_setting($field, array(
-            'label'			=> __('Appearance','acf'),
-            'instructions'	=> __('Select the appearance of this field', 'acf'),
+            'label'			=> __('Appearance','acfe'),
+            'instructions'	=> __('Select the appearance of this field', 'acfe'),
             'type'			=> 'select',
             'name'			=> 'field_type',
             'optgroup'		=> true,
             'choices'		=> array(
-                'checkbox'  => __('Checkbox', 'acf'),
-                'radio'     => __('Radio Buttons', 'acf'),
-                'select'    => _x('Select', 'noun', 'acf')
+                'checkbox'  => __('Checkbox', 'acfe'),
+                'radio'     => __('Radio Buttons', 'acfe'),
+                'select'    => _x('Select', 'noun', 'acfe')
             )
         ));
         
         // default_value
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Default Value','acf'),
-			'instructions'	=> __('Enter each default value on a new line','acf'),
+			'label'			=> __('Default Value','acfe'),
+			'instructions'	=> __('Enter each default value on a new line','acfe'),
 			'name'			=> 'default_value',
 			'type'			=> 'textarea',
 		));
         
         // return_format
         acf_render_field_setting($field, array(
-            'label'			=> __('Return Value', 'acf'),
+            'label'			=> __('Return Value', 'acfe'),
             'instructions'	=> '',
             'type'			=> 'radio',
             'name'			=> 'return_format',
@@ -98,7 +98,7 @@ class acfe_field_post_statuses extends acf_field{
         
 		// Select + Radio: allow_null
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Allow Null?','acf'),
+			'label'			=> __('Allow Null?','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'allow_null',
 			'type'			=> 'true_false',
@@ -123,11 +123,11 @@ class acfe_field_post_statuses extends acf_field{
         
         // placeholder
         acf_render_field_setting($field, array(
-            'label'			=> __('Placeholder Text','acf'),
-            'instructions'	=> __('Appears within the input','acf'),
+            'label'			=> __('Placeholder Text','acfe'),
+            'instructions'	=> __('Appears within the input','acfe'),
             'type'			=> 'text',
             'name'			=> 'placeholder',
-            'placeholder'   => _x('Select', 'verb', 'acf'),
+            'placeholder'   => _x('Select', 'verb', 'acfe'),
             'conditional_logic' => array(
                 array(
                     array(
@@ -160,7 +160,7 @@ class acfe_field_post_statuses extends acf_field{
         
         // Select: multiple
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Select multiple values?','acf'),
+			'label'			=> __('Select multiple values?','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'multiple',
 			'type'			=> 'true_false',
@@ -178,7 +178,7 @@ class acfe_field_post_statuses extends acf_field{
         
         // Select: ui
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Stylised UI','acf'),
+			'label'			=> __('Stylised UI','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'ui',
 			'type'			=> 'true_false',
@@ -197,7 +197,7 @@ class acfe_field_post_statuses extends acf_field{
 		
 		// Select: ajax
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Use AJAX to lazy load choices?','acf'),
+			'label'			=> __('Use AJAX to lazy load choices?','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'ajax',
 			'type'			=> 'true_false',
@@ -220,12 +220,12 @@ class acfe_field_post_statuses extends acf_field{
 		
 		// Radio: other_choice
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Other','acf'),
+			'label'			=> __('Other','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'other_choice',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Add 'other' choice to allow for custom values", 'acf'),
+			'message'		=> __("Add 'other' choice to allow for custom values", 'acfe'),
             'conditions' => array(
                 array(
                     array(
@@ -240,12 +240,12 @@ class acfe_field_post_statuses extends acf_field{
 		
 		// Radio: save_other_choice
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Save Other','acf'),
+			'label'			=> __('Save Other','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'save_other_choice',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Save 'other' values to the field's choices", 'acf'),
+			'message'		=> __("Save 'other' values to the field's choices", 'acfe'),
             'conditions' => array(
                 array(
                     array(
@@ -264,14 +264,14 @@ class acfe_field_post_statuses extends acf_field{
         
         // Checkbox: layout
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Layout','acf'),
+			'label'			=> __('Layout','acfe'),
 			'instructions'	=> '',
 			'type'			=> 'radio',
 			'name'			=> 'layout',
 			'layout'		=> 'horizontal', 
 			'choices'		=> array(
-				'vertical'		=> __("Vertical",'acf'), 
-				'horizontal'	=> __("Horizontal",'acf')
+				'vertical'		=> __("Vertical",'acfe'), 
+				'horizontal'	=> __("Horizontal",'acfe')
 			),
             'conditions' => array(
                 array(
@@ -293,8 +293,8 @@ class acfe_field_post_statuses extends acf_field{
         
         // Checkbox: toggle
         acf_render_field_setting( $field, array(
-			'label'			=> __('Toggle','acf'),
-			'instructions'	=> __('Prepend an extra checkbox to toggle all choices','acf'),
+			'label'			=> __('Toggle','acfe'),
+			'instructions'	=> __('Prepend an extra checkbox to toggle all choices','acfe'),
 			'name'			=> 'toggle',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
@@ -311,12 +311,12 @@ class acfe_field_post_statuses extends acf_field{
         
         // Checkbox: other_choice
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Allow Custom','acf'),
+			'label'			=> __('Allow Custom','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'allow_custom',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Allow 'custom' values to be added", 'acf'),
+			'message'		=> __("Allow 'custom' values to be added", 'acfe'),
             'conditions' => array(
                 array(
                     array(
@@ -331,12 +331,12 @@ class acfe_field_post_statuses extends acf_field{
 		
 		// Checkbox: save_other_choice
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Save Custom','acf'),
+			'label'			=> __('Save Custom','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'save_custom',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Save 'custom' values to the field's choices", 'acf'),
+			'message'		=> __("Save 'custom' values to the field's choices", 'acfe'),
             'conditions' => array(
                 array(
                     array(

--- a/includes/fields/field-post-types.php
+++ b/includes/fields/field-post-types.php
@@ -50,7 +50,7 @@ class acfe_field_post_types extends acf_field{
         
         // Allow Post Type
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Allow Post Type','acf'),
+			'label'			=> __('Allow Post Type','acfe'),
 			'instructions'	=> '',
 			'type'			=> 'select',
 			'name'			=> 'post_type',
@@ -58,34 +58,34 @@ class acfe_field_post_types extends acf_field{
 			'multiple'		=> 1,
 			'ui'			=> 1,
 			'allow_null'	=> 1,
-			'placeholder'	=> __("All post types",'acf'),
+			'placeholder'	=> __("All post types",'acfe'),
 		));
         
         // field_type
         acf_render_field_setting($field, array(
-            'label'			=> __('Appearance','acf'),
-            'instructions'	=> __('Select the appearance of this field', 'acf'),
+            'label'			=> __('Appearance','acfe'),
+            'instructions'	=> __('Select the appearance of this field', 'acfe'),
             'type'			=> 'select',
             'name'			=> 'field_type',
             'optgroup'		=> true,
             'choices'		=> array(
-                'checkbox'  => __('Checkbox', 'acf'),
-                'radio'     => __('Radio Buttons', 'acf'),
-                'select'    => _x('Select', 'noun', 'acf')
+                'checkbox'  => __('Checkbox', 'acfe'),
+                'radio'     => __('Radio Buttons', 'acfe'),
+                'select'    => _x('Select', 'noun', 'acfe')
             )
         ));
         
         // default_value
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Default Value','acf'),
-			'instructions'	=> __('Enter each default value on a new line','acf'),
+			'label'			=> __('Default Value','acfe'),
+			'instructions'	=> __('Enter each default value on a new line','acfe'),
 			'name'			=> 'default_value',
 			'type'			=> 'textarea',
 		));
         
         // return_format
         acf_render_field_setting($field, array(
-            'label'			=> __('Return Value', 'acf'),
+            'label'			=> __('Return Value', 'acfe'),
             'instructions'	=> '',
             'type'			=> 'radio',
             'name'			=> 'return_format',
@@ -98,7 +98,7 @@ class acfe_field_post_types extends acf_field{
         
 		// Select + Radio: allow_null
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Allow Null?','acf'),
+			'label'			=> __('Allow Null?','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'allow_null',
 			'type'			=> 'true_false',
@@ -123,11 +123,11 @@ class acfe_field_post_types extends acf_field{
         
         // placeholder
         acf_render_field_setting($field, array(
-            'label'			=> __('Placeholder Text','acf'),
-            'instructions'	=> __('Appears within the input','acf'),
+            'label'			=> __('Placeholder Text','acfe'),
+            'instructions'	=> __('Appears within the input','acfe'),
             'type'			=> 'text',
             'name'			=> 'placeholder',
-            'placeholder'   => _x('Select', 'verb', 'acf'),
+            'placeholder'   => _x('Select', 'verb', 'acfe'),
             'conditional_logic' => array(
                 array(
                     array(
@@ -160,7 +160,7 @@ class acfe_field_post_types extends acf_field{
         
         // Select: multiple
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Select multiple values?','acf'),
+			'label'			=> __('Select multiple values?','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'multiple',
 			'type'			=> 'true_false',
@@ -178,7 +178,7 @@ class acfe_field_post_types extends acf_field{
         
         // Select: ui
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Stylised UI','acf'),
+			'label'			=> __('Stylised UI','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'ui',
 			'type'			=> 'true_false',
@@ -197,7 +197,7 @@ class acfe_field_post_types extends acf_field{
 		
 		// Select: ajax
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Use AJAX to lazy load choices?','acf'),
+			'label'			=> __('Use AJAX to lazy load choices?','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'ajax',
 			'type'			=> 'true_false',
@@ -220,12 +220,12 @@ class acfe_field_post_types extends acf_field{
 		
 		// Radio: other_choice
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Other','acf'),
+			'label'			=> __('Other','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'other_choice',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Add 'other' choice to allow for custom values", 'acf'),
+			'message'		=> __("Add 'other' choice to allow for custom values", 'acfe'),
             'conditions' => array(
                 array(
                     array(
@@ -240,12 +240,12 @@ class acfe_field_post_types extends acf_field{
 		
 		// Radio: save_other_choice
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Save Other','acf'),
+			'label'			=> __('Save Other','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'save_other_choice',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Save 'other' values to the field's choices", 'acf'),
+			'message'		=> __("Save 'other' values to the field's choices", 'acfe'),
             'conditions' => array(
                 array(
                     array(
@@ -264,14 +264,14 @@ class acfe_field_post_types extends acf_field{
         
         // Checkbox: layout
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Layout','acf'),
+			'label'			=> __('Layout','acfe'),
 			'instructions'	=> '',
 			'type'			=> 'radio',
 			'name'			=> 'layout',
 			'layout'		=> 'horizontal', 
 			'choices'		=> array(
-				'vertical'		=> __("Vertical",'acf'), 
-				'horizontal'	=> __("Horizontal",'acf')
+				'vertical'		=> __("Vertical",'acfe'), 
+				'horizontal'	=> __("Horizontal",'acfe')
 			),
             'conditions' => array(
                 array(
@@ -293,8 +293,8 @@ class acfe_field_post_types extends acf_field{
         
         // Checkbox: toggle
         acf_render_field_setting( $field, array(
-			'label'			=> __('Toggle','acf'),
-			'instructions'	=> __('Prepend an extra checkbox to toggle all choices','acf'),
+			'label'			=> __('Toggle','acfe'),
+			'instructions'	=> __('Prepend an extra checkbox to toggle all choices','acfe'),
 			'name'			=> 'toggle',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
@@ -311,12 +311,12 @@ class acfe_field_post_types extends acf_field{
         
         // Checkbox: other_choice
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Allow Custom','acf'),
+			'label'			=> __('Allow Custom','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'allow_custom',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Allow 'custom' values to be added", 'acf'),
+			'message'		=> __("Allow 'custom' values to be added", 'acfe'),
             'conditions' => array(
                 array(
                     array(
@@ -331,12 +331,12 @@ class acfe_field_post_types extends acf_field{
 		
 		// Checkbox: save_other_choice
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Save Custom','acf'),
+			'label'			=> __('Save Custom','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'save_custom',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Save 'custom' values to the field's choices", 'acf'),
+			'message'		=> __("Save 'custom' values to the field's choices", 'acfe'),
             'conditions' => array(
                 array(
                     array(

--- a/includes/fields/field-recaptcha.php
+++ b/includes/fields/field-recaptcha.php
@@ -8,7 +8,7 @@ class acfe_field_recaptcha extends acf_field{
     function __construct(){
         
         $this->name = 'acfe_recaptcha';
-        $this->label = __('reCAPTCHA', 'acf');
+        $this->label = __('reCAPTCHA', 'acfe');
         $this->category = 'jquery';
         $this->defaults = array(
             'required'      => 0,
@@ -30,25 +30,25 @@ class acfe_field_recaptcha extends acf_field{
         
         // Version
         acf_render_field_setting($field, array(
-            'label'			=> __('Version', 'acf'),
-            'instructions'	=> __('Select the reCaptcha version', 'acf'),
+            'label'			=> __('Version', 'acfe'),
+            'instructions'	=> __('Select the reCaptcha version', 'acfe'),
             'type'			=> 'select',
             'name'			=> 'version',
             'choices'		=> array(
-                'v2'    => __('reCaptcha V2', 'acf'),
-                'v3'    => __('reCaptcha V3', 'acf'),
+                'v2'    => __('reCaptcha V2', 'acfe'),
+                'v3'    => __('reCaptcha V3', 'acfe'),
             )
         ));
         
         // V2 Theme
         acf_render_field_setting($field, array(
-            'label'			=> __('Theme', 'acf'),
-            'instructions'	=> __('Select the reCaptcha theme', 'acf'),
+            'label'			=> __('Theme', 'acfe'),
+            'instructions'	=> __('Select the reCaptcha theme', 'acfe'),
             'type'			=> 'select',
             'name'			=> 'v2_theme',
             'choices'		=> array(
-                'light' => __('Light', 'acf'),
-                'dark'  => __('Dark', 'acf'),
+                'light' => __('Light', 'acfe'),
+                'dark'  => __('Dark', 'acfe'),
             ),
             'conditional_logic' => array(
                 array(
@@ -63,13 +63,13 @@ class acfe_field_recaptcha extends acf_field{
         
         // V2 Size
         acf_render_field_setting($field, array(
-            'label'			=> __('Size', 'acf'),
-            'instructions'	=> __('Select the reCaptcha size', 'acf'),
+            'label'			=> __('Size', 'acfe'),
+            'instructions'	=> __('Select the reCaptcha size', 'acfe'),
             'type'			=> 'select',
             'name'			=> 'v2_size',
             'choices'		=> array(
-                'normal'    => __('Normal', 'acf'),
-                'compact'   => __('Compact', 'acf'),
+                'normal'    => __('Normal', 'acfe'),
+                'compact'   => __('Compact', 'acfe'),
             ),
             'conditional_logic' => array(
                 array(
@@ -84,8 +84,8 @@ class acfe_field_recaptcha extends acf_field{
         
         // V3 Hide Logo
         acf_render_field_setting($field, array(
-            'label'			=> __('Hide logo', 'acf'),
-            'instructions'	=> __('Hide the reCaptcha logo', 'acf'),
+            'label'			=> __('Hide logo', 'acfe'),
+            'instructions'	=> __('Hide the reCaptcha logo', 'acfe'),
             'type'			=> 'true_false',
             'name'			=> 'v3_hide_logo',
             'ui'            => true,
@@ -102,16 +102,16 @@ class acfe_field_recaptcha extends acf_field{
         
         // Site Key
         acf_render_field_setting($field, array(
-            'label'			=> __('Site key', 'acf'),
-            'instructions'	=> __('Enter the site key. <a href="https://www.google.com/recaptcha/admin" target="_blank">reCaptcha API Admin</a>', 'acf'),
+            'label'			=> __('Site key', 'acfe'),
+            'instructions'	=> __('Enter the site key. <a href="https://www.google.com/recaptcha/admin" target="_blank">reCaptcha API Admin</a>', 'acfe'),
             'type'			=> 'text',
             'name'			=> 'site_key',
         ));
         
         // Site Secret
         acf_render_field_setting($field, array(
-            'label'			=> __('Secret key', 'acf'),
-            'instructions'	=> __('Enter the secret key. <a href="https://www.google.com/recaptcha/admin" target="_blank">reCaptcha API Admin</a>', 'acf'),
+            'label'			=> __('Secret key', 'acfe'),
+            'instructions'	=> __('Enter the secret key. <a href="https://www.google.com/recaptcha/admin" target="_blank">reCaptcha API Admin</a>', 'acfe'),
             'type'			=> 'text',
             'name'			=> 'secret_key',
         ));
@@ -222,14 +222,14 @@ class acfe_field_recaptcha extends acf_field{
         // Expired
         if($value === 'expired'){
             
-            return __('reCaptcha has expired.');
+            return __('reCaptcha has expired.', 'acfe');
 
         }
         
         // Error
         elseif($value === 'error'){
             
-            return __('An error has occured.');
+            return __('An error has occured.', 'acfe');
 
         }
         

--- a/includes/fields/field-repeater.php
+++ b/includes/fields/field-repeater.php
@@ -11,10 +11,10 @@ function acfe_repeater_settings($field){
     
     // Stylised button
     acf_render_field_setting($field, array(
-        'label'         => __('Stylised Button'),
+        'label'         => __('Stylised Button', 'acfe') ,
         'name'          => 'acfe_repeater_stylised_button',
         'key'           => 'acfe_repeater_stylised_button',
-        'instructions'  => __('Better row button integration'),
+        'instructions'  => __('Better row button integration', 'acfe'),
         'type'          => 'true_false',
         'message'       => '',
         'default_value' => false,

--- a/includes/fields/field-select.php
+++ b/includes/fields/field-select.php
@@ -8,11 +8,11 @@ function acfe_field_select_settings($field){
     
     // placeholder
     acf_render_field_setting($field, array(
-        'label'			=> __('Placeholder Text','acf'),
-        'instructions'	=> __('Appears within the input','acf'),
+        'label'			=> __('Placeholder Text','acfe'),
+        'instructions'	=> __('Appears within the input','acfe'),
         'type'			=> 'text',
         'name'			=> 'placeholder',
-        'placeholder'   => _x('Select', 'verb', 'acf'),
+        'placeholder'   => _x('Select', 'verb', 'acfe'),
         'conditional_logic' => array(
             array(
                 array(

--- a/includes/fields/field-slug.php
+++ b/includes/fields/field-slug.php
@@ -36,8 +36,8 @@ class acfe_field_slug extends acf_field{
         
         // default_value
         acf_render_field_setting($field, array(
-            'label'			=> __('Default Value','acf'),
-            'instructions'	=> __('Appears when creating a new post','acf'),
+            'label'			=> __('Default Value','acfe'),
+            'instructions'	=> __('Appears when creating a new post','acfe'),
             'type'			=> 'text',
             'name'			=> 'default_value',
         ));
@@ -45,8 +45,8 @@ class acfe_field_slug extends acf_field{
         
         // placeholder
         acf_render_field_setting($field, array(
-            'label'			=> __('Placeholder Text','acf'),
-            'instructions'	=> __('Appears within the input','acf'),
+            'label'			=> __('Placeholder Text','acfe'),
+            'instructions'	=> __('Appears within the input','acfe'),
             'type'			=> 'text',
             'name'			=> 'placeholder',
         ));
@@ -54,8 +54,8 @@ class acfe_field_slug extends acf_field{
         
         // prepend
         acf_render_field_setting($field, array(
-            'label'			=> __('Prepend','acf'),
-            'instructions'	=> __('Appears before the input','acf'),
+            'label'			=> __('Prepend','acfe'),
+            'instructions'	=> __('Appears before the input','acfe'),
             'type'			=> 'text',
             'name'			=> 'prepend',
         ));
@@ -63,8 +63,8 @@ class acfe_field_slug extends acf_field{
         
         // append
         acf_render_field_setting($field, array(
-            'label'			=> __('Append','acf'),
-            'instructions'	=> __('Appears after the input','acf'),
+            'label'			=> __('Append','acfe'),
+            'instructions'	=> __('Appears after the input','acfe'),
             'type'			=> 'text',
             'name'			=> 'append',
         ));
@@ -72,8 +72,8 @@ class acfe_field_slug extends acf_field{
         
         // maxlength
         acf_render_field_setting($field, array(
-            'label'			=> __('Character Limit','acf'),
-            'instructions'	=> __('Leave blank for no limit','acf'),
+            'label'			=> __('Character Limit','acfe'),
+            'instructions'	=> __('Leave blank for no limit','acfe'),
             'type'			=> 'number',
             'name'			=> 'maxlength',
         ));
@@ -85,7 +85,7 @@ class acfe_field_slug extends acf_field{
         $value = sanitize_title($value);
         
         if($field['maxlength'] && mb_strlen(wp_unslash($value)) > $field['maxlength'])
-            return sprintf(__('Value must not exceed %d characters', 'acf'), $field['maxlength']);
+            return sprintf(__('Value must not exceed %d characters', 'acfe'), $field['maxlength']);
         
         return $valid;
         

--- a/includes/fields/field-taxonomies.php
+++ b/includes/fields/field-taxonomies.php
@@ -50,7 +50,7 @@ class acfe_field_taxonomies extends acf_field{
         
         // Allow Taxonomy
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Allow Taxonomy','acf'),
+			'label'			=> __('Allow Taxonomy','acfe'),
 			'instructions'	=> '',
 			'type'			=> 'select',
 			'name'			=> 'taxonomy',
@@ -58,34 +58,34 @@ class acfe_field_taxonomies extends acf_field{
 			'multiple'		=> 1,
 			'ui'			=> 1,
 			'allow_null'	=> 1,
-			'placeholder'	=> __("All taxonomies",'acf'),
+			'placeholder'	=> __("All taxonomies",'acfe'),
 		));
         
         // field_type
         acf_render_field_setting($field, array(
-            'label'			=> __('Appearance','acf'),
-            'instructions'	=> __('Select the appearance of this field', 'acf'),
+            'label'			=> __('Appearance','acfe'),
+            'instructions'	=> __('Select the appearance of this field', 'acfe'),
             'type'			=> 'select',
             'name'			=> 'field_type',
             'optgroup'		=> true,
             'choices'		=> array(
-                'checkbox'  => __('Checkbox', 'acf'),
-                'radio'     => __('Radio Buttons', 'acf'),
-                'select'    => _x('Select', 'noun', 'acf')
+                'checkbox'  => __('Checkbox', 'acfe'),
+                'radio'     => __('Radio Buttons', 'acfe'),
+                'select'    => _x('Select', 'noun', 'acfe')
             )
         ));
         
         // default_value
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Default Value','acf'),
-			'instructions'	=> __('Enter each default value on a new line','acf'),
+			'label'			=> __('Default Value','acfe'),
+			'instructions'	=> __('Enter each default value on a new line','acfe'),
 			'name'			=> 'default_value',
 			'type'			=> 'textarea',
 		));
         
         // return_format
         acf_render_field_setting($field, array(
-            'label'			=> __('Return Value', 'acf'),
+            'label'			=> __('Return Value', 'acfe'),
             'instructions'	=> '',
             'type'			=> 'radio',
             'name'			=> 'return_format',
@@ -98,7 +98,7 @@ class acfe_field_taxonomies extends acf_field{
         
 		// Select + Radio: allow_null
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Allow Null?','acf'),
+			'label'			=> __('Allow Null?','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'allow_null',
 			'type'			=> 'true_false',
@@ -123,8 +123,8 @@ class acfe_field_taxonomies extends acf_field{
         
         // placeholder
         acf_render_field_setting($field, array(
-            'label'			=> __('Placeholder Text','acf'),
-            'instructions'	=> __('Appears within the input','acf'),
+            'label'			=> __('Placeholder Text','acfe'),
+            'instructions'	=> __('Appears within the input','acfe'),
             'type'			=> 'text',
             'name'			=> 'placeholder',
             'placeholder'   => _x('Select', 'verb', 'acf'),
@@ -160,7 +160,7 @@ class acfe_field_taxonomies extends acf_field{
         
         // Select: multiple
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Select multiple values?','acf'),
+			'label'			=> __('Select multiple values?','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'multiple',
 			'type'			=> 'true_false',
@@ -178,7 +178,7 @@ class acfe_field_taxonomies extends acf_field{
         
         // Select: ui
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Stylised UI','acf'),
+			'label'			=> __('Stylised UI','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'ui',
 			'type'			=> 'true_false',
@@ -197,7 +197,7 @@ class acfe_field_taxonomies extends acf_field{
 		
 		// Select: ajax
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Use AJAX to lazy load choices?','acf'),
+			'label'			=> __('Use AJAX to lazy load choices?','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'ajax',
 			'type'			=> 'true_false',
@@ -220,12 +220,12 @@ class acfe_field_taxonomies extends acf_field{
 		
 		// Radio: other_choice
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Other','acf'),
+			'label'			=> __('Other','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'other_choice',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Add 'other' choice to allow for custom values", 'acf'),
+			'message'		=> __("Add 'other' choice to allow for custom values", 'acfe'),
             'conditions' => array(
                 array(
                     array(
@@ -240,12 +240,12 @@ class acfe_field_taxonomies extends acf_field{
 		
 		// Radio: save_other_choice
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Save Other','acf'),
+			'label'			=> __('Save Other','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'save_other_choice',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Save 'other' values to the field's choices", 'acf'),
+			'message'		=> __("Save 'other' values to the field's choices", 'acfe'),
             'conditions' => array(
                 array(
                     array(
@@ -264,14 +264,14 @@ class acfe_field_taxonomies extends acf_field{
         
         // Checkbox: layout
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Layout','acf'),
+			'label'			=> __('Layout','acfe'),
 			'instructions'	=> '',
 			'type'			=> 'radio',
 			'name'			=> 'layout',
 			'layout'		=> 'horizontal', 
 			'choices'		=> array(
-				'vertical'		=> __("Vertical",'acf'), 
-				'horizontal'	=> __("Horizontal",'acf')
+				'vertical'		=> __("Vertical",'acfe'), 
+				'horizontal'	=> __("Horizontal",'acfe')
 			),
             'conditions' => array(
                 array(
@@ -293,8 +293,8 @@ class acfe_field_taxonomies extends acf_field{
         
         // Checkbox: toggle
         acf_render_field_setting( $field, array(
-			'label'			=> __('Toggle','acf'),
-			'instructions'	=> __('Prepend an extra checkbox to toggle all choices','acf'),
+			'label'			=> __('Toggle','acfe'),
+			'instructions'	=> __('Prepend an extra checkbox to toggle all choices','acfe'),
 			'name'			=> 'toggle',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
@@ -311,12 +311,12 @@ class acfe_field_taxonomies extends acf_field{
         
         // Checkbox: other_choice
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Allow Custom','acf'),
+			'label'			=> __('Allow Custom','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'allow_custom',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Allow 'custom' values to be added", 'acf'),
+			'message'		=> __("Allow 'custom' values to be added", 'acfe'),
             'conditions' => array(
                 array(
                     array(
@@ -331,12 +331,12 @@ class acfe_field_taxonomies extends acf_field{
 		
 		// Checkbox: save_other_choice
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Save Custom','acf'),
+			'label'			=> __('Save Custom','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'save_custom',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Save 'custom' values to the field's choices", 'acf'),
+			'message'		=> __("Save 'custom' values to the field's choices", 'acfe'),
             'conditions' => array(
                 array(
                     array(

--- a/includes/fields/field-taxonomy-terms.php
+++ b/includes/fields/field-taxonomy-terms.php
@@ -147,7 +147,7 @@ class acfe_field_taxonomy_terms extends acf_field{
                 if($i === 1){
                     
                     $id = 'all_' . $term->taxonomy;
-                    $text = 'All ';
+                    $text = __('All ', 'acfe');
                     $taxonomy = get_taxonomy($term->taxonomy);
                     
                     if($options['level'] >= 1){
@@ -373,7 +373,7 @@ class acfe_field_taxonomy_terms extends acf_field{
         
         // Allow Taxonomy
 		acf_render_field_setting($field, array(
-			'label'			=> __('Allow Taxonomy','acf'),
+			'label'			=> __('Allow Taxonomy','acfe'),
 			'instructions'	=> '',
 			'type'			=> 'select',
 			'name'			=> 'taxonomy',
@@ -381,7 +381,7 @@ class acfe_field_taxonomy_terms extends acf_field{
 			'multiple'		=> 1,
 			'ui'			=> 1,
 			'allow_null'	=> 1,
-			'placeholder'	=> __("All taxonomies",'acf'),
+			'placeholder'	=> __("All taxonomies",'acfe'),
 		));
         
         // Allow Terms
@@ -452,7 +452,7 @@ class acfe_field_taxonomy_terms extends acf_field{
         }
         
 		acf_render_field_setting($field, array(
-			'label'			=> __('Allow Terms','acf'),
+			'label'			=> __('Allow Terms','acfe'),
 			'instructions'	=> '',
 			'type'			=> 'select',
 			'name'			=> 'allow_terms',
@@ -461,47 +461,47 @@ class acfe_field_taxonomy_terms extends acf_field{
 			'ui'			=> 1,
 			'allow_null'	=> 1,
             'ajax'          => 1,
-			'placeholder'	=> __("All terms",'acf'),
+			'placeholder'	=> __("All terms",'acfe'),
 			'ajax_action'	=> 'acfe/fields/taxonomy_terms/allow_query',
 		));
         
         // Select: Terms level
 		acf_render_field_setting($field, array(
-			'label'			=> __('Terms_level','acf'),
+			'label'			=> __('Terms_level','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'allow_level',
 			'type'			=> 'number',
 			'append'        => 'levels',
 			'min'           => 0,
-			'placeholder'   => __('All','acf'),
+			'placeholder'   => __('All','acfe'),
             '_append'       => 'allow_terms',
             'value'         => false
 		));
         
         // field_type
         acf_render_field_setting($field, array(
-            'label'			=> __('Appearance','acf'),
-            'instructions'	=> __('Select the appearance of this field', 'acf'),
+            'label'			=> __('Appearance','acfe'),
+            'instructions'	=> __('Select the appearance of this field', 'acfe'),
             'type'			=> 'select',
             'name'			=> 'field_type',
             'optgroup'		=> true,
             'choices'		=> array(
-                'checkbox'  => __('Checkbox', 'acf'),
-                'select'    => _x('Select', 'noun', 'acf')
+                'checkbox'  => __('Checkbox', 'acfe'),
+                'select'    => _x('Select', 'noun', 'acfe')
             )
         ));
         
         // default_value
 		acf_render_field_setting($field, array(
-			'label'			=> __('Default Value','acf'),
-			'instructions'	=> __('Enter each default value on a new line','acf'),
+			'label'			=> __('Default Value','acfe'),
+			'instructions'	=> __('Enter each default value on a new line','acfe'),
 			'name'			=> 'default_value',
 			'type'			=> 'textarea',
 		));
         
         // return_format
         acf_render_field_setting($field, array(
-            'label'			=> __('Return Value', 'acf'),
+            'label'			=> __('Return Value', 'acfe'),
             'instructions'	=> '',
             'type'			=> 'radio',
             'name'			=> 'return_format',
@@ -515,7 +515,7 @@ class acfe_field_taxonomy_terms extends acf_field{
         
         // Select: ui
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Stylised UI','acf'),
+			'label'			=> __('Stylised UI','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'ui',
 			'type'			=> 'true_false',
@@ -533,7 +533,7 @@ class acfe_field_taxonomy_terms extends acf_field{
         
         // Select: allow_null
 		acf_render_field_setting($field, array(
-			'label'			=> __('Allow Null?','acf'),
+			'label'			=> __('Allow Null?','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'allow_null',
 			'type'			=> 'true_false',
@@ -551,11 +551,11 @@ class acfe_field_taxonomy_terms extends acf_field{
         
         // placeholder
         acf_render_field_setting($field, array(
-            'label'			=> __('Placeholder Text','acf'),
-            'instructions'	=> __('Appears within the input','acf'),
+            'label'			=> __('Placeholder Text','acfe'),
+            'instructions'	=> __('Appears within the input','acfe'),
             'type'			=> 'text',
             'name'			=> 'placeholder',
-            'placeholder'   => _x('Select', 'verb', 'acf'),
+            'placeholder'   => _x('Select', 'verb', 'acfe'),
             'conditional_logic' => array(
                 array(
                     array(
@@ -588,7 +588,7 @@ class acfe_field_taxonomy_terms extends acf_field{
         
         // Select: multiple
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Select multiple values?','acf'),
+			'label'			=> __('Select multiple values?','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'multiple',
 			'type'			=> 'true_false',
@@ -606,7 +606,7 @@ class acfe_field_taxonomy_terms extends acf_field{
         
 		// Select: ajax
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Use AJAX to lazy load choices?','acf'),
+			'label'			=> __('Use AJAX to lazy load choices?','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'ajax',
 			'type'			=> 'true_false',
@@ -629,14 +629,14 @@ class acfe_field_taxonomy_terms extends acf_field{
         
         // Checkbox: layout
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Layout','acf'),
+			'label'			=> __('Layout','acfe'),
 			'instructions'	=> '',
 			'type'			=> 'radio',
 			'name'			=> 'layout',
 			'layout'		=> 'horizontal', 
 			'choices'		=> array(
-				'vertical'		=> __("Vertical",'acf'), 
-				'horizontal'	=> __("Horizontal",'acf')
+				'vertical'		=> __("Vertical",'acfe'), 
+				'horizontal'	=> __("Horizontal",'acfe')
 			),
             'conditions' => array(
                 array(
@@ -651,8 +651,8 @@ class acfe_field_taxonomy_terms extends acf_field{
         
         // Checkbox: toggle
         acf_render_field_setting( $field, array(
-			'label'			=> __('Toggle','acf'),
-			'instructions'	=> __('Prepend an extra checkbox to toggle all choices','acf'),
+			'label'			=> __('Toggle','acfe'),
+			'instructions'	=> __('Prepend an extra checkbox to toggle all choices','acfe'),
 			'name'			=> 'toggle',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
@@ -669,8 +669,8 @@ class acfe_field_taxonomy_terms extends acf_field{
         
         // save_terms
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Save Terms','acf'),
-			'instructions'	=> __('Connect selected terms to the post','acf'),
+			'label'			=> __('Save Terms','acfe'),
+			'instructions'	=> __('Connect selected terms to the post','acfe'),
 			'name'			=> 'save_terms',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
@@ -678,8 +678,8 @@ class acfe_field_taxonomy_terms extends acf_field{
         
 		// load_terms
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Load Terms','acf'),
-			'instructions'	=> __('Load value from posts terms','acf'),
+			'label'			=> __('Load Terms','acfe'),
+			'instructions'	=> __('Load value from posts terms','acfe'),
 			'name'			=> 'load_terms',
 			'type'			=> 'true_false',
 			'ui'			=> 1,

--- a/includes/fields/field-taxonomy-terms.php
+++ b/includes/fields/field-taxonomy-terms.php
@@ -147,7 +147,7 @@ class acfe_field_taxonomy_terms extends acf_field{
                 if($i === 1){
                     
                     $id = 'all_' . $term->taxonomy;
-                    $text = __('All ', 'acfe');
+                    $text = __('All', 'acfe');
                     $taxonomy = get_taxonomy($term->taxonomy);
                     
                     if($options['level'] >= 1){

--- a/includes/fields/field-textarea.php
+++ b/includes/fields/field-textarea.php
@@ -8,10 +8,10 @@ add_action('acf/render_field_settings/type=textarea', 'acfe_field_textarea_setti
 function acfe_field_textarea_settings($field){
     
     acf_render_field_setting($field, array(
-        'label'         => __('Code mode'),
+        'label'         => __('Code mode', 'acfe'),
         'name'          => 'acfe_textarea_code',
         'key'           => 'acfe_textarea_code',
-        'instructions'  => __('Switch font family to monospace and allow tab indent. For a more advanced code editor, please use the <code>Code Editor</code> field type'),
+        'instructions'  => __('Switch font family to monospace and allow tab indent. For a more advanced code editor, please use the <code>Code Editor</code> field type', 'acfe'),
         'type'			=> 'true_false',
         'ui'			=> 1,
     ));

--- a/includes/fields/field-user-roles.php
+++ b/includes/fields/field-user-roles.php
@@ -49,7 +49,7 @@ class acfe_field_user_roles extends acf_field{
         
         // Allow User Role
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Allow User Role','acf'),
+			'label'			=> __('Allow User Role','acfe'),
 			'instructions'	=> '',
 			'type'			=> 'select',
 			'name'			=> 'user_role',
@@ -57,34 +57,34 @@ class acfe_field_user_roles extends acf_field{
 			'multiple'		=> 1,
 			'ui'			=> 1,
 			'allow_null'	=> 1,
-			'placeholder'	=> __("All user roles",'acf'),
+			'placeholder'	=> __("All user roles",'acfe'),
 		));
         
         // field_type
         acf_render_field_setting($field, array(
-            'label'			=> __('Appearance','acf'),
-            'instructions'	=> __('Select the appearance of this field', 'acf'),
+            'label'			=> __('Appearance','acfe'),
+            'instructions'	=> __('Select the appearance of this field', 'acfe'),
             'type'			=> 'select',
             'name'			=> 'field_type',
             'optgroup'		=> true,
             'choices'		=> array(
                 'checkbox'  => __('Checkbox', 'acf'),
-                'radio'     => __('Radio Buttons', 'acf'),
-                'select'    => _x('Select', 'noun', 'acf')
+                'radio'     => __('Radio Buttons', 'acfe'),
+                'select'    => _x('Select', 'noun', 'acfe')
             )
         ));
         
         // default_value
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Default Value','acf'),
-			'instructions'	=> __('Enter each default value on a new line','acf'),
+			'label'			=> __('Default Value','acfe'),
+			'instructions'	=> __('Enter each default value on a new line','acfe'),
 			'name'			=> 'default_value',
 			'type'			=> 'textarea',
 		));
         
 		// Select + Radio: allow_null
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Allow Null?','acf'),
+			'label'			=> __('Allow Null?','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'allow_null',
 			'type'			=> 'true_false',
@@ -109,11 +109,11 @@ class acfe_field_user_roles extends acf_field{
         
         // placeholder
         acf_render_field_setting($field, array(
-            'label'			=> __('Placeholder Text','acf'),
-            'instructions'	=> __('Appears within the input','acf'),
+            'label'			=> __('Placeholder Text','acfe'),
+            'instructions'	=> __('Appears within the input','acfe'),
             'type'			=> 'text',
             'name'			=> 'placeholder',
-            'placeholder'   => _x('Select', 'verb', 'acf'),
+            'placeholder'   => _x('Select', 'verb', 'acfe'),
             'conditional_logic' => array(
                 array(
                     array(
@@ -146,7 +146,7 @@ class acfe_field_user_roles extends acf_field{
         
         // Select: multiple
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Select multiple values?','acf'),
+			'label'			=> __('Select multiple values?','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'multiple',
 			'type'			=> 'true_false',
@@ -164,7 +164,7 @@ class acfe_field_user_roles extends acf_field{
         
         // Select: ui
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Stylised UI','acf'),
+			'label'			=> __('Stylised UI','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'ui',
 			'type'			=> 'true_false',
@@ -183,7 +183,7 @@ class acfe_field_user_roles extends acf_field{
 		
 		// Select: ajax
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Use AJAX to lazy load choices?','acf'),
+			'label'			=> __('Use AJAX to lazy load choices?','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'ajax',
 			'type'			=> 'true_false',
@@ -206,12 +206,12 @@ class acfe_field_user_roles extends acf_field{
 		
 		// Radio: other_choice
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Other','acf'),
+			'label'			=> __('Other','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'other_choice',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Add 'other' choice to allow for custom values", 'acf'),
+			'message'		=> __("Add 'other' choice to allow for custom values", 'acfe'),
             'conditions' => array(
                 array(
                     array(
@@ -226,12 +226,12 @@ class acfe_field_user_roles extends acf_field{
 		
 		// Radio: save_other_choice
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Save Other','acf'),
+			'label'			=> __('Save Other','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'save_other_choice',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Save 'other' values to the field's choices", 'acf'),
+			'message'		=> __("Save 'other' values to the field's choices", 'acfe'),
             'conditions' => array(
                 array(
                     array(
@@ -250,14 +250,14 @@ class acfe_field_user_roles extends acf_field{
         
         // Checkbox: layout
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Layout','acf'),
+			'label'			=> __('Layout','acfe'),
 			'instructions'	=> '',
 			'type'			=> 'radio',
 			'name'			=> 'layout',
 			'layout'		=> 'horizontal', 
 			'choices'		=> array(
-				'vertical'		=> __("Vertical",'acf'), 
-				'horizontal'	=> __("Horizontal",'acf')
+				'vertical'		=> __("Vertical",'acfe'), 
+				'horizontal'	=> __("Horizontal",'acfe')
 			),
             'conditions' => array(
                 array(
@@ -279,8 +279,8 @@ class acfe_field_user_roles extends acf_field{
         
         // Checkbox: toggle
         acf_render_field_setting( $field, array(
-			'label'			=> __('Toggle','acf'),
-			'instructions'	=> __('Prepend an extra checkbox to toggle all choices','acf'),
+			'label'			=> __('Toggle','acfr'),
+			'instructions'	=> __('Prepend an extra checkbox to toggle all choices','acfe'),
 			'name'			=> 'toggle',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
@@ -297,12 +297,12 @@ class acfe_field_user_roles extends acf_field{
         
         // Checkbox: other_choice
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Allow Custom','acf'),
+			'label'			=> __('Allow Custom','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'allow_custom',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Allow 'custom' values to be added", 'acf'),
+			'message'		=> __("Allow 'custom' values to be added", 'acfe'),
             'conditions' => array(
                 array(
                     array(
@@ -317,12 +317,12 @@ class acfe_field_user_roles extends acf_field{
 		
 		// Checkbox: save_other_choice
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Save Custom','acf'),
+			'label'			=> __('Save Custom','acfe'),
 			'instructions'	=> '',
 			'name'			=> 'save_custom',
 			'type'			=> 'true_false',
 			'ui'			=> 1,
-			'message'		=> __("Save 'custom' values to the field's choices", 'acf'),
+			'message'		=> __("Save 'custom' values to the field's choices", 'acfe'),
             'conditions' => array(
                 array(
                     array(

--- a/includes/locations/post-type-archive.php
+++ b/includes/locations/post-type-archive.php
@@ -38,7 +38,7 @@ class acfe_location_post_type_archive{
             
             acf_add_options_page(array(
                 'page_title' 	            => $object->label . ' Archive',
-                'menu_title'	            => 'Archive',
+                'menu_title'	            => __('Archive', 'acfe'), 
                 'menu_slug' 	            => $name . '-archive',
                 'post_id'                   => $name . '_archive',
                 'capability'	            => acf_get_setting('capability'),
@@ -80,7 +80,7 @@ class acfe_location_post_type_archive{
     
     function location_types($choices){
         
-        $name = __('Post', 'acf');
+        $name = __('Post', 'acfe');
         
         $choices[$name] = acfe_array_insert_after('post_type', $choices[$name], 'post_type_archive', __('Post Type Archive'));
 

--- a/includes/locations/post-type-list.php
+++ b/includes/locations/post-type-list.php
@@ -373,9 +373,9 @@ class acfe_location_post_type_list{
     
     function location_types($choices){
         
-        $name = __('Post', 'acf');
+        $name = __('Post', 'acfe');
         
-        $choices[$name] = acfe_array_insert_after('post_type', $choices[$name], 'post_type_list', __('Post Type List'));
+        $choices[$name] = acfe_array_insert_after('post_type', $choices[$name], 'post_type_list', __('Post Type List', 'acfe'));
 
         return $choices;
         

--- a/includes/locations/taxonomy-list.php
+++ b/includes/locations/taxonomy-list.php
@@ -364,9 +364,9 @@ class acfe_location_taxonomy_list{
     
     function location_types($choices){
         
-        $name = __('Forms', 'acf');
+        $name = __('Forms', 'acfe');
         
-        $choices[$name] = acfe_array_insert_after('taxonomy', $choices[$name], 'taxonomy_list', __('Taxonomy List'));
+        $choices[$name] = acfe_array_insert_after('taxonomy', $choices[$name], 'taxonomy_list', __('Taxonomy List', 'acfe'));
 
         return $choices;
         
@@ -374,7 +374,7 @@ class acfe_location_taxonomy_list{
     
     function location_values($choices){
         
-		$choices = array('all' => __('All', 'acf'));
+		$choices = array('all' => __('All', 'acfe'));
 		$choices = array_merge($choices, acf_get_taxonomy_labels());
         
         return $choices;

--- a/includes/modules/dev.php
+++ b/includes/modules/dev.php
@@ -201,7 +201,7 @@ class acfe_dev{
         
             <thead>
                 <tr>
-                    <th scope="col" style="width:30%;">Name</th>
+                    <th scope="col" style="width:30%;"><?php __('Name', 'acfe') ?></th>
                     <th scope="col" style="width:auto;">Value</th>
                 </tr>
             </thead>
@@ -322,7 +322,7 @@ class acfe_dev{
             if(empty($value)){
                 
                 $css = 'color:#aaa;';
-                $value = '(' . __('empty', 'acf') . ')';
+                $value = '(' . __('empty', 'acfe') . ')';
                 
             }
             

--- a/includes/modules/dynamic-block-type.php
+++ b/includes/modules/dynamic-block-type.php
@@ -480,8 +480,8 @@ function acfe_dbt_admin_row($actions, $post){
     $post_id = $post->ID;
     $name = get_field('name', $post_id);
     
-    $actions['acfe_dpt_export_php'] = '<a href="' . admin_url('edit.php?post_type=acf-field-group&page=acf-tools&tool=acfe_tool_dbt_export&action=php&keys=' . $name) . '">' . __('PHP') . '</a>';
-    $actions['acfe_dpt_export_json'] = '<a href="' . admin_url('edit.php?post_type=acf-field-group&page=acf-tools&tool=acfe_tool_dbt_export&action=json&keys=' . $name) . '">' . __('Json') . '</a>';
+    $actions['acfe_dpt_export_php'] = '<a href="' . admin_url('edit.php?post_type=acf-field-group&page=acf-tools&tool=acfe_tool_dbt_export&action=php&keys=' . $name) . '">' . __('PHP','acfe') . '</a>';
+    $actions['acfe_dpt_export_json'] = '<a href="' . admin_url('edit.php?post_type=acf-field-group&page=acf-tools&tool=acfe_tool_dbt_export&action=json&keys=' . $name) . '">' . __('Json','acfe') . '</a>';
     
     return $actions;
     
@@ -662,10 +662,9 @@ function acfe_dbt_get_fields_labels_recursive(&$array, $field){
 /**
  * Add Local Field Group
  */
-acf_add_local_field_group(array(
+acf_add_local_field_group (array(
     'key' => 'group_acfe_dynamic_block_type',
     'title' => __('Dynamic Block Type', 'acfe'),
-    
     'location' => array(
         array(
             array(
@@ -732,8 +731,7 @@ acf_add_local_field_group(array(
             'label' => __('Name', 'acfe'),
             'name' => 'name',
             'type' => 'acfe_slug',
-            'instructions' => __('(String) A unique name that identifies the block (without namespace).<br />
-Note: A block name can only contain lowercase alphanumeric characters and dashes, and must begin with a letter.', 'acfe'),
+            'instructions' => __('(String) A unique name that identifies the block (without namespace).<br />Note: A block name can only contain lowercase alphanumeric characters and dashes, and must begin with a letter.', 'acfe'),
             'required' => 1,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -803,11 +801,7 @@ Note: A block name can only contain lowercase alphanumeric characters and dashes
             'label' => __('Keywords', 'acfe'),
             'name' => 'keywords',
             'type' => 'textarea',
-            'instructions' => __('(Array) (Optional) An array of search terms to help user discover the block while searching.<br />
-One line for each keyword. ie:<br /><br />
-quote<br />
-mention<br />
-cite', 'acfe'),
+            'instructions' => __('(Array) (Optional) An array of search terms to help user discover the block while searching.<br />One line for each keyword. ie:<br /><br />quote<br />mention<br />cite', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -848,12 +842,7 @@ cite', 'acfe'),
             'label' => __('Mode', 'acfe'),
             'name' => 'mode',
             'type' => 'select',
-            'instructions' => __('(String) (Optional) The display mode for your block. Available settings are “auto”, “preview” and “edit”. Defaults to “auto”.<br /><br />
-auto: Preview is shown by default but changes to edit form when block is selected.<br />
-preview: Preview is always shown. Edit form appears in sidebar when block is selected.<br />
-edit: Edit form is always shown.<br /><br />
-
-Note. When in “preview” or “edit” modes, an icon will appear in the block toolbar to toggle between modes.', 'acfe'),
+            'instructions' => __('(String) (Optional) The display mode for your block. Available settings are “auto”, “preview” and “edit”. Defaults to “auto”.<br /><br /> auto: Preview is shown by default but changes to edit form when block is selected.<br /> preview: Preview is always shown. Edit form appears in sidebar when block is selected.<br /> edit: Edit form is always shown.<br /><br /> Note. When in “preview” or “edit” modes, an icon will appear in the block toolbar to toggle between modes.', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -936,8 +925,7 @@ Note. When in “preview” or “edit” modes, an icon will appear in the bloc
             'label' => __('Icon Type', 'acfe'),
             'name' => 'icon_type',
             'type' => 'select',
-            'instructions' => __('Simple: Specify a Dashicons class or SVG path<br />
-Colors: Specify colors & Dashicons class', 'acfe'),
+            'instructions' => __('Simple: Specify a Dashicons class or SVG path<br /> Colors: Specify colors & Dashicons class', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -1116,7 +1104,7 @@ Colors: Specify colors & Dashicons class', 'acfe'),
         ),
         array(
             'key' => 'field_acfe_dbt_render_callback',
-            'label' => __('Render callback',
+            'label' => __('Render callback', 'afce'),
             'name' => 'render_callback',
             'type' => 'text',
             'instructions' => __('(Callable) (Optional) Instead of providing a render_template, a callback function name may be specified to output the block’s HTML.', 'acfe'),
@@ -1267,11 +1255,7 @@ Colors: Specify colors & Dashicons class', 'acfe'),
             'label' => __('Align arguments', 'acfe'),
             'name' => 'supports_align_args',
             'type' => 'textarea',
-            'instructions' => __('Set to an array of specific alignment names to customize the toolbar.<br />
-One line for each name. ie:<br /><br />
-left<br />
-right<br />
-full', 'acfe'),
+            'instructions' => __('Set to an array of specific alignment names to customize the toolbar.<br />One line for each name. ie:<br /><br />left<br />right<br />full', 'acfe'),
             'required' => 0,
             'conditional_logic' => array(
                 array(

--- a/includes/modules/dynamic-options-page.php
+++ b/includes/modules/dynamic-options-page.php
@@ -14,14 +14,14 @@ add_action('init', 'acfe_dop_register');
 function acfe_dop_register(){
     
     register_post_type('acfe-dop', array(
-        'label'                 => 'Options Page',
-        'description'           => 'Options Page',
+        'label'                 => __('Options Page', 'acfe'),
+        'description'           => __('Options Page', 'acfe'),
         'labels'                => array(
-            'name'          => 'Options Pages',
-            'singular_name' => 'Options Page',
-            'menu_name'     => 'Options Pages',
-            'edit_item'     => 'Edit Options Page',
-            'add_new_item'  => 'New Options Page',
+            'name'          => __('Options Pages', 'acfe'),
+            'singular_name' => __('Options Page', 'acfe'),
+            'menu_name'     => __('Options Pages', 'acfe'),
+            'edit_item'     => __('Edit Options Page', 'acfe'),
+            'add_new_item'  => __('New Options Page', 'acfe'),
         ),
         'supports'              => false,
         'hierarchical'          => true,
@@ -60,7 +60,7 @@ function acfe_dop_menu(){
     if(!acf_get_setting('show_admin'))
         return;
     
-    add_submenu_page('edit.php?post_type=acf-field-group', __('Options'), __('Options'), acf_get_setting('capability'), 'edit.php?post_type=acfe-dop');
+    add_submenu_page('edit.php?post_type=acf-field-group', __('Options', 'acfe'), __('Options', 'acfe'), acf_get_setting('capability'), 'edit.php?post_type=acfe-dop');
     
 }
 
@@ -376,9 +376,9 @@ function acfe_dop_admin_columns($columns){
     if(isset($columns['date']))
         unset($columns['date']);
     
-    $columns['name'] = __('Name');
-    $columns['post_id'] = __('Post ID');
-    $columns['autoload'] = __('Autoload');
+    $columns['name'] = __('Name', 'acfe');
+    $columns['post_id'] = __('Post ID', 'acfe');
+    $columns['autoload'] = __('Autoload', 'acfe');
     
     return $columns;
     
@@ -435,8 +435,8 @@ function acfe_dop_admin_row($actions, $post){
     
     $name = get_field('acfe_dop_name', $post->ID);
     
-    $actions['acfe_dop_export_php'] = '<a href="' . admin_url('edit.php?post_type=acf-field-group&page=acf-tools&tool=acfe_tool_dop_export&action=php&keys=' . $name) . '">' . __('PHP') . '</a>';
-    $actions['acfe_dop_export_json'] = '<a href="' . admin_url('edit.php?post_type=acf-field-group&page=acf-tools&tool=acfe_tool_dop_export&action=json&keys=' . $name) . '">' . __('Json') . '</a>';
+    $actions['acfe_dop_export_php'] = '<a href="' . admin_url('edit.php?post_type=acf-field-group&page=acf-tools&tool=acfe_tool_dop_export&action=php&keys=' . $name) . '">' . __('PHP', 'acfe') . '</a>';
+    $actions['acfe_dop_export_json'] = '<a href="' . admin_url('edit.php?post_type=acf-field-group&page=acf-tools&tool=acfe_tool_dop_export&action=json&keys=' . $name) . '">' . __('Json', 'acfe') . '</a>';
     
     return $actions;
     
@@ -546,7 +546,7 @@ acf_add_local_field_group(array(
             'label' => __('Name', 'acfe'),
             'name' => 'acfe_dop_name',
             'type' => 'acfe_slug',
-            'instructions' => __('(string) Options page slug. Must be unique', 'acfe'),
+            'instructions' => __('(String) Options page slug. Must be unique', 'acfe'),
             'required' => 1,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -568,7 +568,7 @@ acf_add_local_field_group(array(
             'label' => __('Menu title', 'acfe'),
             'name' => 'menu_title',
             'type' => 'text',
-            'instructions' => __('(string) The title displayed in the wp-admin sidebar. Defaults to page_title', 'acfe'),
+            'instructions' => __('(String) The title displayed in the wp-admin sidebar. Defaults to page_title', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -590,7 +590,7 @@ acf_add_local_field_group(array(
             'label' => 'Menu slug',
             'name' => 'menu_slug',
             'type' => 'acfe_slug',
-            'instructions' => __('(string) The URL slug used to uniquely identify this options page. Defaults to a url friendly version of menu_title', 'acfe'),
+            'instructions' => __('(String) The URL slug used to uniquely identify this options page. Defaults to a url friendly version of menu_title', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -616,7 +616,7 @@ acf_add_local_field_group(array(
             'label' => __('Capability', 'acfe'),
             'name' => 'capability',
             'type' => 'text',
-            'instructions' => __('(string) The capability required for this menu to be displayed to the user. Defaults to edit_posts.<br /><br />
+            'instructions' => __('(String) The capability required for this menu to be displayed to the user. Defaults to edit_posts.<br /><br />
 
 Read more about capability here: <a href="https://codex.wordpress.org/Roles_and_Capabilities">https://codex.wordpress.org/Roles_and_Capabilities</a>', 'acfe'),
             'required' => 0,
@@ -640,7 +640,7 @@ Read more about capability here: <a href="https://codex.wordpress.org/Roles_and_
             'label' => __('Position', 'acfe'),
             'name' => 'position',
             'type' => 'text',
-            'instructions' => __('(int|string) The position in the menu order this menu should appear. Defaults to bottom of utility menu items.<br /><br />
+            'instructions' => __('(Int|String) The position in the menu order this menu should appear. Defaults to bottom of utility menu items.<br /><br />
 
 WARNING: if two menu items use the same position attribute, one of the items may be overwritten so that only one item displays!<br />
 Risk of conflict can be reduced by using decimal instead of integer values, e.g. \'63.3\' instead of 63 (must use quotes).', 'acfe'),
@@ -665,7 +665,7 @@ Risk of conflict can be reduced by using decimal instead of integer values, e.g.
             'label' => __('Parent slug', 'acfe'),
             'name' => 'parent_slug',
             'type' => 'text',
-            'instructions' => __('(string) The slug of another WP admin page. if set, this will become a child page.', 'acfe'),
+            'instructions' => __('(String) The slug of another WP admin page. if set, this will become a child page.', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -687,7 +687,7 @@ Risk of conflict can be reduced by using decimal instead of integer values, e.g.
             'label' => __('Icon url', 'acfe'),
             'name' => 'icon_url',
             'type' => 'text',
-            'instructions' => __('(string) The icon class for this menu. Defaults to default WordPress gear.<br /><br />
+            'instructions' => __('(String) The icon class for this menu. Defaults to default WordPress gear.<br /><br />
 Read more about dashicons here: <a href="https://developer.wordpress.org/resource/dashicons/">https://developer.wordpress.org/resource/dashicons/</a>', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
@@ -710,7 +710,7 @@ Read more about dashicons here: <a href="https://developer.wordpress.org/resourc
             'label' => __('Redirect', 'acfe'),
             'name' => 'redirect',
             'type' => 'true_false',
-            'instructions' => __('(boolean) If set to true, this options page will redirect to the first child page (if a child page exists). 
+            'instructions' => __('(Boolean) If set to true, this options page will redirect to the first child page (if a child page exists). 
 If set to false, this parent page will appear alongside any child pages. Defaults to true', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
@@ -733,7 +733,7 @@ If set to false, this parent page will appear alongside any child pages. Default
             'label' => __('Post ID', 'acfe'),
             'name' => 'post_id',
             'type' => 'text',
-            'instructions' => __('(int|string) The \'$post_id\' to save/load data to/from. Can be set to a numeric post ID (123), or a string (\'user_2\'). 
+            'instructions' => __('(Int|String) The \'$post_id\' to save/load data to/from. Can be set to a numeric post ID (123), or a string (\'user_2\'). 
 Defaults to \'options\'.', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
@@ -756,7 +756,7 @@ Defaults to \'options\'.', 'acfe'),
             'label' => __('Autoload', 'acfe'),
             'name' => 'autoload',
             'type' => 'true_false',
-            'instructions' => __('(boolean)    Whether to load the option (values saved from this options page) when WordPress starts up.
+            'instructions' => __('(Boolean)    Whether to load the option (values saved from this options page) when WordPress starts up.
 Defaults to false.', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
@@ -779,7 +779,7 @@ Defaults to false.', 'acfe'),
             'label' => __('Update button', 'acfe'),
             'name' => 'update_button',
             'type' => 'text',
-            'instructions' => __('(string) The update button text.', 'acfe'),
+            'instructions' => __('(String) The update button text.', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -801,7 +801,7 @@ Defaults to false.', 'acfe'),
             'label' => __('Updated Message', 'acfe'),
             'name' => 'updated_message',
             'type' => 'text',
-            'instructions' => __('(string) The message shown above the form on submit.', 'acfe'),
+            'instructions' => __('(String) The message shown above the form on submit.', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(

--- a/includes/modules/dynamic-options-page.php
+++ b/includes/modules/dynamic-options-page.php
@@ -14,14 +14,14 @@ add_action('init', 'acfe_dop_register');
 function acfe_dop_register(){
     
     register_post_type('acfe-dop', array(
-        'label'                 => __('Options Page', 'acfe'),
-        'description'           => __('Options Page', 'acfe'),
+        'label'                 => 'Options Page',
+        'description'           => 'Options Page',
         'labels'                => array(
-            'name'          => __('Options Pages', 'acfe'),
-            'singular_name' => __('Options Page', 'acfe'),
-            'menu_name'     => __('Options Pages', 'acfe'),
-            'edit_item'     => __('Edit Options Page', 'acfe'),
-            'add_new_item'  => __('New Options Page', 'acfe'),
+            'name'          => 'Options Pages',
+            'singular_name' => 'Options Page',
+            'menu_name'     => 'Options Pages',
+            'edit_item'     => 'Edit Options Page',
+            'add_new_item'  => 'New Options Page',
         ),
         'supports'              => false,
         'hierarchical'          => true,
@@ -376,9 +376,9 @@ function acfe_dop_admin_columns($columns){
     if(isset($columns['date']))
         unset($columns['date']);
     
-    $columns['name'] = __('Name', 'acfe');
-    $columns['post_id'] = __('Post ID', 'acfe');
-    $columns['autoload'] = __('Autoload', 'acfe');
+    $columns['name'] = __('Name');
+    $columns['post_id'] = __('Post ID');
+    $columns['autoload'] = __('Autoload');
     
     return $columns;
     
@@ -510,10 +510,10 @@ acf_add_local_field_group(array(
     ),
     
     'menu_order' => 0,
-    'position' => 'normal',
-    'style' => 'default',
-    'label_placement' => 'left',
-    'instruction_placement' => 'label',
+    'position' => __('normal', 'acfe'),
+    'style' => __('default', 'acfe'),
+    'label_placement' => __('left', 'acfe'),
+    'instruction_placement' => __('label', 'acfe'),
     'hide_on_screen' => '',
     'active' => 1,
     'description' => '',
@@ -521,10 +521,10 @@ acf_add_local_field_group(array(
     'fields' => array(
         array(
             'key' => 'field_acfe_dop_page_title',
-            'label' => '__(Page title', 'acfe'),
+            'label' => __('Page title', 'acfe'),
             'name' => 'page_title',
             'type' => 'text',
-            'instructions' => __('(string) The title displayed on the options page. Required.', 'acfe'),
+            'instructions' => '(string) The title displayed on the options page. Required.',
             'required' => 1,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -587,7 +587,7 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_dop_menu_slug',
-            'label' => __('Menu slug', 'acfe'),
+            'label' => 'Menu slug',
             'name' => 'menu_slug',
             'type' => 'acfe_slug',
             'instructions' => __('(string) The URL slug used to uniquely identify this options page. Defaults to a url friendly version of menu_title', 'acfe'),
@@ -725,8 +725,8 @@ If set to false, this parent page will appear alongside any child pages. Default
             'message' => '',
             'default_value' => 1,
             'ui' => 1,
-            'ui_on_text' => 'True',
-            'ui_off_text' => 'False',
+            'ui_on_text' => __('True', 'acfe'),
+            'ui_off_text' => __('False', 'acfe'),
         ),
         array(
             'key' => 'field_acfe_dop_post_id',
@@ -745,7 +745,7 @@ Defaults to \'options\'.', 'acfe'),
             'acfe_validate' => '',
             'acfe_update' => '',
             'acfe_permissions' => '',
-            'default_value' => 'options',
+            'default_value' => __('options', 'acfe'),
             'placeholder' => '',
             'prepend' => '',
             'append' => '',
@@ -756,7 +756,7 @@ Defaults to \'options\'.', 'acfe'),
             'label' => __('Autoload', 'acfe'),
             'name' => 'autoload',
             'type' => 'true_false',
-            'instructions' => __('(boolean)	Whether to load the option (values saved from this options page) when WordPress starts up.
+            'instructions' => __('(boolean)    Whether to load the option (values saved from this options page) when WordPress starts up.
 Defaults to false.', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
@@ -771,8 +771,8 @@ Defaults to false.', 'acfe'),
             'message' => '',
             'default_value' => 0,
             'ui' => 1,
-            'ui_on_text' => 'True',
-            'ui_off_text' => 'False',
+            'ui_on_text' => __('True', 'acfe'),
+            'ui_off_text' => __('False', 'acfe'),
         ),
         array(
             'key' => 'field_acfe_dop_update_button',
@@ -812,7 +812,7 @@ Defaults to false.', 'acfe'),
             'acfe_validate' => '',
             'acfe_update' => '',
             'acfe_permissions' => '',
-            'default_value' => __('Options Updated', 'acfe'),
+            'default_value' => 'Options Updated',
             'placeholder' => '',
             'prepend' => '',
             'append' => '',

--- a/includes/modules/form/actions/custom.php
+++ b/includes/modules/form/actions/custom.php
@@ -26,7 +26,7 @@ class acfe_form_custom{
         );
         
         if(in_array($value, $reserved))
-            $valid = 'This action name is not authorized';
+            $valid = __('This action name is not authorized', 'acfe');
         
         return $valid;
     }

--- a/includes/modules/form/actions/post.php
+++ b/includes/modules/form/actions/post.php
@@ -314,7 +314,7 @@ class acfe_form_post{
             if(!empty($temp_title)){
                 
                 $_post_id = wp_insert_post(array(
-                    'post_title' => 'Post'
+                    'post_title' => __('Post', 'acfe')
                 ));
             
             }
@@ -587,7 +587,7 @@ function my_form_post_values_source($post_id, $form, $action){
             
         }
         
-        ?>You may use the following hooks:<br /><br />
+        echo __('You may use the following hooks:', 'acfe') ?><br /><br />
 <pre>
 add_filter('acfe/form/submit/post_args', 'my_form_post_args', 10, 4);
 add_filter('acfe/form/submit/post_args/form=<?php echo $form_name; ?>', 'my_form_post_args', 10, 4);
@@ -652,7 +652,7 @@ function my_form_post_args($args, $type, $form, $action){
             
         }
         
-        ?>You may use the following hooks:<br /><br />
+         echo __('You may use the following hooks:', 'acfe') ?><br /><br />
 <pre>
 add_action('acfe/form/submit/post', 'my_form_post_save', 10, 5);
 add_action('acfe/form/submit/post/form=<?php echo $form_name; ?>', 'my_form_post_save', 10, 5);

--- a/includes/modules/form/actions/term.php
+++ b/includes/modules/form/actions/term.php
@@ -387,7 +387,7 @@ class acfe_form_term{
         if(acf_maybe_get($field, 'value'))
             $form_name = get_field('acfe_form_name', $field['value']);
         
-        ?>You may use the following hooks:<br /><br />
+        echo __('You may use the following hooks:', 'acfe') ?><br /><br />
 <pre>
 add_filter('acfe/form/load/term_id', 'my_form_term_values_source', 10, 3);
 add_filter('acfe/form/load/term_id/form=<?php echo $form_name; ?>', 'my_form_term_values_source', 10, 3);
@@ -428,7 +428,7 @@ function my_form_term_values_source($term_id, $form, $action){
         if(acf_maybe_get($field, 'value'))
             $form_name = get_field('acfe_form_name', $field['value']);
         
-        ?>You may use the following hooks:<br /><br />
+        echo __('You may use the following hooks:', 'acfe') ?><br /><br />
 <pre>
 add_filter('acfe/form/submit/term_args', 'my_form_term_args', 10, 4);
 add_filter('acfe/form/submit/term_args/form=<?php echo $form_name; ?>', 'my_form_term_args', 10, 4);
@@ -488,7 +488,7 @@ function my_form_term_args($args, $type, $form, $action){
         if(acf_maybe_get($field, 'value'))
             $form_name = get_field('acfe_form_name', $field['value']);
         
-        ?>You may use the following hooks:<br /><br />
+        echo __('You may use the following hooks:', 'acfe') ?><br /><br />
 <pre>
 add_action('acfe/form/submit/term', 'my_form_term_save', 10, 5);
 add_action('acfe/form/submit/term/form=<?php echo $form_name; ?>', 'my_form_term_save', 10, 5);

--- a/includes/modules/form/actions/user.php
+++ b/includes/modules/form/actions/user.php
@@ -526,17 +526,17 @@ class acfe_form_user{
                     
                     if(empty($user_login)){
                         
-                        $error = new WP_Error('empty_user_login', __('Cannot create a user with an empty login name.'));
+                        $error = new WP_Error('empty_user_login', __('Cannot create a user with an empty login name.', 'acfe'));
                         
                     }elseif(mb_strlen($user_login) > 60){
                         
-                        $error = new WP_Error('user_login_too_long', __('Username may not be longer than 60 characters.'));
+                        $error = new WP_Error('user_login_too_long', __('Username may not be longer than 60 characters.', 'acfe'));
                         
                     }
                     
                     if(username_exists($user_login)){
                         
-                        $error = new WP_Error('existing_user_login', __('Sorry, that username already exists!'));
+                        $error = new WP_Error('existing_user_login', __('Sorry, that username already exists!', 'acfe'));
                         
                     }
                     
@@ -544,7 +544,7 @@ class acfe_form_user{
                     
                     if(mb_strlen($user_nicename) > 50){
                         
-                        $error = new WP_Error('user_nicename_too_long', __('Nicename may not be longer than 50 characters.'));
+                        $error = new WP_Error('user_nicename_too_long', __('Nicename may not be longer than 50 characters.', 'acfe'));
                         
                     }
                     
@@ -622,7 +622,7 @@ class acfe_form_user{
         if(acf_maybe_get($field, 'value'))
             $form_name = get_field('acfe_form_name', $field['value']);
         
-        ?>You may use the following hooks:<br /><br />
+        echo __('You may use the following hooks:', 'acfe') ?><br /><br />
 <pre>
 add_filter('acfe/form/load/user_id', 'my_form_user_values_source', 10, 3);
 add_filter('acfe/form/load/user_id/form=<?php echo $form_name; ?>', 'my_form_user_values_source', 10, 3);
@@ -663,7 +663,7 @@ function my_form_user_values_source($user_id, $form, $action){
         if(acf_maybe_get($field, 'value'))
             $form_name = get_field('acfe_form_name', $field['value']);
         
-        ?>You may use the following hooks:<br /><br />
+        echo __('You may use the following hooks:', 'acfe') ?><br /><br />
 <pre>
 add_filter('acfe/form/submit/user_args', 'my_form_user_args', 10, 4);
 add_filter('acfe/form/submit/user_args/form=<?php echo $form_name; ?>', 'my_form_user_args', 10, 4);
@@ -723,7 +723,7 @@ function my_form_user_args($args, $type, $form, $action){
         if(acf_maybe_get($field, 'value'))
             $form_name = get_field('acfe_form_name', $field['value']);
         
-        ?>You may use the following hooks:<br /><br />
+        echo __('You may use the following hooks:', 'acfe') ?><br /><br />
 <pre>
 add_action('acfe/form/submit/user', 'my_form_user_save', 10, 5);
 add_action('acfe/form/submit/user/form=<?php echo $form_name; ?>', 'my_form_user_save', 10, 5);

--- a/includes/modules/form/admin.php
+++ b/includes/modules/form/admin.php
@@ -243,7 +243,7 @@ class acfe_form{
         
         ?>
         <div class="misc-pub-section misc-pub-acfe-field-group-export" style="padding-top:2px;">
-            <span style="font-size:17px;color: #82878c;line-height: 1.3;width: 20px;margin-right: 2px;" class="dashicons dashicons-editor-code"></span> <?php echo ('Export:', 'acfe') ?> <a href="<?php echo admin_url('edit.php?post_type=acf-field-group&page=acf-tools&tool=acfe_tool_form_export&action=json&keys=' . $name); ?>">Json</a>
+            <span style="font-size:17px;color: #82878c;line-height: 1.3;width: 20px;margin-right: 2px;" class="dashicons dashicons-editor-code"></span> <?php echo __('Export:', 'acfe') ?> <a href="<?php echo admin_url('edit.php?post_type=acf-field-group&page=acf-tools&tool=acfe_tool_form_export&action=json&keys=' . $name); ?>">Json</a>
         </div>
         <?php
         
@@ -426,10 +426,10 @@ class acfe_form{
                         
                         <table class="acf-table">
                             <thead>
-                                <th class="acf-th" width="25%"><strong><?php echo ('Label', 'acfe') ?></strong></th>
-                                <th class="acf-th" width="25%"><strong><?php echo ('Name', 'acfe') ?></strong></th>
-                                <th class="acf-th" width="25%"><strong><?php echo ('Key', 'acfe') ?></strong></th>
-                                <th class="acf-th" width="25%"><strong><?php echo ('Type', 'acfe') ?></strong></th>
+                                <th class="acf-th" width="25%"><strong><?php echo __('Label', 'acfe') ?></strong></th>
+                                <th class="acf-th" width="25%"><strong><?php echo __('Name', 'acfe') ?></strong></th>
+                                <th class="acf-th" width="25%"><strong><?php echo __('Key', 'acfe') ?></strong></th>
+                                <th class="acf-th" width="25%"><strong><?php echo __('Type', 'acfe') ?></strong></th>
                             </thead>
                             
                             <tbody>
@@ -1202,7 +1202,7 @@ function my_<?php echo $_field_name; ?>_validation($valid, $value, $field, $inpu
                 $fields[] = array(
                     'type'      => 'message',
                     'name'      => '',
-                    'label'     => __('PHP Field Validation', 'acfe')
+                    'label'     => __('PHP Field Validation', 'acfe'),
                     'value'     => '',
                     'message'   => $html,
                     'new_lines' => false,

--- a/includes/modules/form/admin.php
+++ b/includes/modules/form/admin.php
@@ -99,14 +99,14 @@ class acfe_form{
         
         // Post Type
         register_post_type($this->post_type, array(
-            'label'                 => __('Forms', 'acf'),
-            'description'           => __('Forms', 'acf'),
+            'label'                 => __('Forms', 'acfe'),
+            'description'           => __('Forms', 'acfe'),
             'labels'                => array(
-                'name'          => __('Forms', 'acf'),
-                'singular_name' => __('Form', 'acf'),
-                'menu_name'     => __('Forms', 'acf'),
-                'edit_item'     => 'Edit Form',
-                'add_new_item'  => 'New Form',
+                'name'          => __('Forms', 'acfe'),
+                'singular_name' => __('Form', 'acfe'),
+                'menu_name'     => __('Forms', 'acfe'),
+                'edit_item'     => __('Edit Form', 'acfe'),
+                'add_new_item'  => __('New Form', 'acfe'),
             ),
             'supports'              => array('title'),
             'hierarchical'          => false,
@@ -141,7 +141,7 @@ class acfe_form{
         if(!acf_get_setting('show_admin'))
             return;
         
-        add_submenu_page('edit.php?post_type=acf-field-group', __('Forms', 'acf'), __('Forms', 'acf'), acf_get_setting('capability'), 'edit.php?post_type=' . $this->post_type);
+        add_submenu_page('edit.php?post_type=acf-field-group', __('Forms', 'acfe'), __('Forms', 'acfe'), acf_get_setting('capability'), 'edit.php?post_type=' . $this->post_type);
         
     }
     
@@ -156,7 +156,7 @@ class acfe_form{
 		global $wp_post_statuses;
 		
 		// modify publish post status
-		$wp_post_statuses['publish']->label_count = _n_noop('Active <span class="count">(%s)</span>', 'Active <span class="count">(%s)</span>', 'acf');
+		$wp_post_statuses['publish']->label_count = _n_noop('Active <span class="count">(%s)</span>', 'Active <span class="count">(%s)</span>', 'acfe');
         
         add_action('load-edit.php',     array($this, 'load_list'));
         add_action('load-post.php',     array($this, 'load_post'));
@@ -243,7 +243,7 @@ class acfe_form{
         
         ?>
         <div class="misc-pub-section misc-pub-acfe-field-group-export" style="padding-top:2px;">
-            <span style="font-size:17px;color: #82878c;line-height: 1.3;width: 20px;margin-right: 2px;" class="dashicons dashicons-editor-code"></span> Export: <a href="<?php echo admin_url('edit.php?post_type=acf-field-group&page=acf-tools&tool=acfe_tool_form_export&action=json&keys=' . $name); ?>">Json</a>
+            <span style="font-size:17px;color: #82878c;line-height: 1.3;width: 20px;margin-right: 2px;" class="dashicons dashicons-editor-code"></span> <?php echo ('Export:', 'acfe') ?> <a href="<?php echo admin_url('edit.php?post_type=acf-field-group&page=acf-tools&tool=acfe_tool_form_export&action=json&keys=' . $name); ?>">Json</a>
         </div>
         <?php
         
@@ -383,7 +383,7 @@ class acfe_form{
             'acfe-form-details', 
             
             // Title
-            __('Fields', 'acf'), 
+            __('Fields', 'acfe'), 
             
             // Render
             array($this, 'render_meta_boxes'), 
@@ -426,10 +426,10 @@ class acfe_form{
                         
                         <table class="acf-table">
                             <thead>
-                                <th class="acf-th" width="25%"><strong>Label</strong></th>
-                                <th class="acf-th" width="25%"><strong>Name</strong></th>
-                                <th class="acf-th" width="25%"><strong>Key</strong></th>
-                                <th class="acf-th" width="25%"><strong>Type</strong></th>
+                                <th class="acf-th" width="25%"><strong><?php echo ('Label', 'acfe') ?></strong></th>
+                                <th class="acf-th" width="25%"><strong><?php echo ('Name', 'acfe') ?></strong></th>
+                                <th class="acf-th" width="25%"><strong><?php echo ('Key', 'acfe') ?></strong></th>
+                                <th class="acf-th" width="25%"><strong><?php echo ('Type', 'acfe') ?></strong></th>
                             </thead>
                             
                             <tbody>
@@ -493,7 +493,7 @@ class acfe_form{
         $ancestors = isset($field['ancestors']) ? $field['ancestors'] : count(acf_get_field_ancestors($field));
         $label = str_repeat('- ', $ancestors) . $label;
         
-        $label .= !empty($field['label']) ? $field['label'] : '(' . __('no label', 'acf') . ')';
+        $label .= !empty($field['label']) ? $field['label'] : '(' . __('no label', 'acfe') . ')';
         $label .= $field['required'] ? ' <span class="acf-required">*</span>' : '';
         
         $array[$field['key']] = $label;
@@ -556,13 +556,13 @@ class acfe_form{
     
     function prepare_actions($field){
         
-        $field['instructions'] = 'Add actions on form submission';
-        
-        $data = $this->fields_groups;
+        $field['instructions'] = __('Add actions on form submission', 'acfe');
+               
+	    $data = $this->fields_groups;
         
         if(empty($data)){
             
-            $field['instructions'] .= '<br /><u>No field groups are currently mapped</u>';
+            $field['instructions'] .= '<br /><u>' . __('No field groups are currently mapped', 'acfe') . '</u>';
             
         }
         
@@ -649,7 +649,7 @@ class acfe_form{
                     // First level
                     if(!$deep){
                         
-                        $label = !empty($field['label']) ? $field['label'] : '(' . __('no label', 'acf') . ')';
+                        $label = !empty($field['label']) ? $field['label'] : '(' . __('no label', 'acfe') . ')';
                         $label .= $field['required'] ? ' *' : '';
                         
                         $choices[$field_group_title][$field['key']] = $label. ' (' . $field['key'] . ')';
@@ -678,7 +678,7 @@ class acfe_form{
         $ancestors = isset($field['ancestors']) ? $field['ancestors'] : count(acf_get_field_ancestors($field));
         $label = str_repeat('- ', $ancestors) . $label;
         
-        $label .= !empty($field['label']) ? $field['label'] : '(' . __('no label', 'acf') . ')';
+        $label .= !empty($field['label']) ? $field['label'] : '(' . __('no label', 'acfe') . ')';
         $label .= $field['required'] ? ' *' : '';
         
         $choices[$field['key']] = $label. ' (' . $field['key'] . ')';
@@ -1130,7 +1130,7 @@ class acfe_form{
         $fields[] = array(
             'type'      => 'message',
             'name'      => '',
-            'label'     => 'Shortcode',
+            'label'     => __('Shortcode', 'acfe'),
             'value'     => '',
             'message'   => '<code>[acfe_form name="' . $form_name . '"]</code> or <code>[acfe_form ID="' . $form_id . '"]</code>',
             'new_lines' => false,
@@ -1149,7 +1149,7 @@ class acfe_form{
         $fields[] = array(
             'type'      => 'message',
             'name'      => '',
-            'label'     => 'PHP Form Integration',
+            'label'     => __('PHP Form Integration', 'acfe'),
             'value'     => '',
             'message'   => $html,
             'new_lines' => false,
@@ -1202,7 +1202,7 @@ function my_<?php echo $_field_name; ?>_validation($valid, $value, $field, $inpu
                 $fields[] = array(
                     'type'      => 'message',
                     'name'      => '',
-                    'label'     => 'PHP Field Validation',
+                    'label'     => __('PHP Field Validation', 'acfe')
                     'value'     => '',
                     'message'   => $html,
                     'new_lines' => false,
@@ -1250,7 +1250,7 @@ function my_<?php echo $_form_name; ?>_validation($form, $post_id){
                 $fields[] = array(
                     'type'      => 'message',
                     'name'      => '',
-                    'label'     => 'PHP Form Validation',
+                    'label'     => __('PHP Form Validation', 'acfe'),
                     'value'     => '',
                     'message'   => $html,
                     'new_lines' => false,
@@ -1298,7 +1298,7 @@ function my_<?php echo $_form_name; ?>_submit($form, $post_id){
                 $fields[] = array(
                     'type'      => 'message',
                     'name'      => '',
-                    'label'     => 'PHP Form Submit: Custom Action',
+                    'label'     => __('PHP Form Submit: Custom Action', 'acfe'),
                     'value'     => '',
                     'message'   => $html,
                     'new_lines' => false,
@@ -1317,10 +1317,10 @@ function my_<?php echo $_form_name; ?>_submit($form, $post_id){
         if(isset($columns['date']))
             unset($columns['date']);
         
-        $columns['name'] = __('Name');
-        $columns['field_groups'] = __('Field groups', 'acf');
-        $columns['actions'] = __('Actions');
-        $columns['shortcode'] = __('Shortcode');
+        $columns['name'] = __('Name', 'acfe');
+        $columns['field_groups'] = __('Field groups', 'acfe');
+        $columns['actions'] = __('Actions', 'acfe');
+        $columns['shortcode'] = __('Shortcode', 'acfe');
         
         return $columns;
         
@@ -1379,7 +1379,7 @@ function my_<?php echo $_form_name; ?>_submit($form, $post_id){
                         
                         $action_name = get_sub_field('acfe_form_custom_action');
                         
-                        $customs[] = '<span class="acf-js-tooltip dashicons dashicons-editor-code" title="Custom action: ' . $action_name . '"></span>';
+                        $customs[] = '<span class="acf-js-tooltip dashicons dashicons-editor-code" title="' . __('Custom action: ', 'acfe') . $action_name . '"></span>';
                         $found = true;
                         
                     }
@@ -1387,7 +1387,7 @@ function my_<?php echo $_form_name; ?>_submit($form, $post_id){
                     // E-mail
                     elseif(get_row_layout() === 'email'){
                         
-                        $emails[] = '<span class="acf-js-tooltip dashicons dashicons-email" title="E-mail"></span>';
+                        $emails[] = '<span class="acf-js-tooltip dashicons dashicons-email" title="' . __('Email ', 'acfe') . '"></span>';
                         $found = true;
                         
                     }
@@ -1400,7 +1400,7 @@ function my_<?php echo $_form_name; ?>_submit($form, $post_id){
                         // Insert
                         if($action === 'insert_post'){
                             
-                            $posts[] = '<span class="acf-js-tooltip dashicons dashicons-edit" title="Create post"></span>';
+                            $posts[] = '<span class="acf-js-tooltip dashicons dashicons-edit" title="' . __('Create post', 'acfe') . '"></span>';
                             $found = true;
                             
                         }
@@ -1408,7 +1408,7 @@ function my_<?php echo $_form_name; ?>_submit($form, $post_id){
                         // Update
                         elseif($action === 'update_post'){
                             
-                            $posts[] = '<span class="acf-js-tooltip dashicons dashicons-update" title="Update post"></span>';
+                            $posts[] = '<span class="acf-js-tooltip dashicons dashicons-update" title="' . __('Update post', 'acfe') . '"></span>';
                             $found = true;
                             
                         }
@@ -1423,7 +1423,7 @@ function my_<?php echo $_form_name; ?>_submit($form, $post_id){
                         // Insert
                         if($action === 'insert_term'){
                             
-                            $terms[] = '<span class="acf-js-tooltip dashicons dashicons-category" title="Create term"></span>';
+                            $terms[] = '<span class="acf-js-tooltip dashicons dashicons-category" title="' . __('Create term', 'acfe') . '"></span>';
                             $found = true;
                             
                         }
@@ -1431,7 +1431,7 @@ function my_<?php echo $_form_name; ?>_submit($form, $post_id){
                         // Update
                         elseif($action === 'update_term'){
                             
-                            $terms[] = '<span class="acf-js-tooltip dashicons dashicons-category" title="Update term"></span>';
+                            $terms[] = '<span class="acf-js-tooltip dashicons dashicons-category" title="' . __('Update term', 'acfe') . '"></span>';
                             $found = true;
                             
                         }
@@ -1446,7 +1446,7 @@ function my_<?php echo $_form_name; ?>_submit($form, $post_id){
                         // Insert
                         if($action === 'insert_user'){
                             
-                            $users[] = '<span class="acf-js-tooltip dashicons dashicons-admin-users" title="Create user"></span>';
+                            $users[] = '<span class="acf-js-tooltip dashicons dashicons-admin-users" title="' . __('Create user', 'acfe') . '"></span>';
                             $found = true;
                             
                         }
@@ -1454,7 +1454,7 @@ function my_<?php echo $_form_name; ?>_submit($form, $post_id){
                         // Update
                         elseif($action === 'update_user'){
                             
-                            $users[] = '<span class="acf-js-tooltip dashicons dashicons-admin-users" title="Update user"></span>';
+                            $users[] = '<span class="acf-js-tooltip dashicons dashicons-admin-users" title="' . __('Update user', 'acfe') . '"></span>';
                             $found = true;
                             
                         }
@@ -1566,11 +1566,11 @@ function my_<?php echo $_form_name; ?>_submit($form, $post_id){
         if(!$is_search && $args['paged'] === 1){
             
             $results[] = array(
-                'text'		=> 'Generic',
+                'text'		=> __('Generic', 'acfe'),
                 'children'	=> array(
                     array(
                         'id'    => 'current_post',
-                        'text'  => 'Current Post',
+                        'text'  => __('Current Post', 'acfe'),
                     )
                 )
             );
@@ -1642,7 +1642,7 @@ function my_<?php echo $_form_name; ?>_submit($form, $post_id){
             return $field;
         
         $field['choices'] = array();
-        $field['choices']['current_post'] = 'Current Post';
+        $field['choices']['current_post'] = __('Current Post', 'acfe');
         
         $field_type = acf_get_field_type('post_object');
         $field['post_type'] = acf_get_post_types();
@@ -1757,15 +1757,15 @@ function my_<?php echo $_form_name; ?>_submit($form, $post_id){
         if(!$is_search && $args['paged'] === 1){
             
             $results[] = array(
-                'text'		=> 'Generic',
+                'text'		=> __('Generic', 'acfe'),
                 'children'	=> array(
                     array(
                         'id'    => 'current_user',
-                        'text'  => 'Current User',
+                        'text'  => __('Current User', 'acfe'),
                     ),
                     array(
                         'id'    => 'current_post_author',
-                        'text'  => 'Current Post Author',
+                        'text'  => __('Current Post Author', 'acfe'),
                     ),
                 )
             );
@@ -1838,9 +1838,9 @@ function my_<?php echo $_form_name; ?>_submit($form, $post_id){
             return $field;
         
         $field['choices'] = array();
-        $field['choices']['current_user'] = 'Current User';
-        $field['choices']['current_post_author'] = 'Current Post Author';
-        
+        $field['choices']['current_user'] = __('Current User', 'acfe');
+        $field['choices']['current_post_author'] = __('Current Post Author', 'acfe');
+		
         $field_type = acf_get_field_type('user');
         
         // Clean value into an array of IDs.
@@ -1938,11 +1938,11 @@ function my_<?php echo $_form_name; ?>_submit($form, $post_id){
         if(!$is_search && $args['paged'] === 1){
             
             $results[] = array(
-                'text'		=> 'Generic',
+                'text'		=> __('Generic', 'acfe'),
                 'children'	=> array(
                     array(
                         'id'    => 'current_term',
-                        'text'  => 'Current Term',
+                        'text'  => __('Current Term', 'acfe'),
                     )
                 )
             );
@@ -2001,7 +2001,7 @@ function my_<?php echo $_form_name; ?>_submit($form, $post_id){
         $value = $field['value'];
         
         $field['choices'] = array();
-        $field['choices']['current_term'] = 'Current Term';
+        $field['choices']['current_term'] = __('Current Term', 'acfe');
         
         if(is_array($value))
             $value = $value[0];

--- a/includes/modules/form/field-group.php
+++ b/includes/modules/form/field-group.php
@@ -3000,7 +3000,7 @@ acf_add_local_field_group(array(
 				'layout_user' => array(
 					'key' => 'layout_user',
 					'name' => 'user',
-					'label' => , __('User action', 'acfe'),
+					'label' => __('User action', 'acfe'),
 					'display' => 'row',
 					'sub_fields' => array(
 						array(

--- a/includes/modules/form/field-group.php
+++ b/includes/modules/form/field-group.php
@@ -5,11 +5,11 @@ if(!defined('ABSPATH'))
 
 acf_add_local_field_group(array(
     'key' => 'group_acfe_dynamic_form',
-    'title' => 'Dynamic Form',
+    'title' => __('Dynamic Form', 'acfe'),
     'fields' => array(
         array(
             'key' => 'field_acfe_form_tab_general',
-            'label' => 'General',
+            'label' => __('General', 'acfe'),
             'name' => '',
             'type' => 'tab',
             'instructions' => '',
@@ -26,10 +26,10 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_name',
-            'label' => 'Form name',
+            'label' => __('Form name', 'acfe'),
             'name' => 'acfe_form_name',
             'type' => 'acfe_slug',
-            'instructions' => 'The unique form slug',
+            'instructions' => __('The unique form slug', 'acfe'),
             'required' => 1,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -46,10 +46,10 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_field_groups',
-            'label' => 'Field groups',
+            'label' => __('Field groups', 'acfe'),
             'name' => 'acfe_form_field_groups',
             'type' => 'select',
-            'instructions' => 'Render & map fields of the following field groups',
+            'instructions' => __('Render & map fields of the following field groups', 'acfe'),
             'required' => 1,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -71,10 +71,10 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_form_element',
-            'label' => 'Form element',
+            'label' => __('Form element', 'acfe'),
             'name' => 'acfe_form_form_element',
             'type' => 'true_false',
-            'instructions' => 'Whether or not to create a <code>&lt;form&gt;</code> element',
+            'instructions' => __('Whether or not to create a <code>&lt;form&gt;</code> element', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -91,10 +91,10 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_attributes',
-            'label' => 'Form attributes',
+            'label' => __('Form attributes', 'acfe'),
             'name' => 'acfe_form_attributes',
             'type' => 'group',
-            'instructions' => 'Form class and id',
+            'instructions' => __('Form class and id', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -204,10 +204,10 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_fields_attributes',
-            'label' => 'Fields class',
+            'label' => __('Fields class', 'acfe'),
             'name' => 'acfe_form_fields_attributes',
             'type' => 'group',
-            'instructions' => 'Add class to all fields',
+            'instructions' => __('Add class to all fields', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -265,10 +265,10 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_html_before_fields',
-            'label' => 'HTML Before render',
+            'label' => __('HTML Before render', 'acfe'),
             'name' => 'acfe_form_html_before_fields',
             'type' => 'acfe_code_editor',
-            'instructions' => 'Extra HTML to add before the fields',
+            'instructions' => __('Extra HTML to add before the fields', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -284,12 +284,12 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_custom_html',
-            'label' => 'HTML Form render',
+            'label' => __('HTML Form render', 'acfe'),
             'name' => 'acfe_form_custom_html',
             'type' => 'acfe_code_editor',
-            'instructions' => 'Render your own customized HTML. This will override the native field groups render.<br /><br />
+            'instructions' => __('Render your own customized HTML. This will override the native field groups render.<br /><br />
     Field groups may be included using <code>{field_group:group_key}</code><br/><code>{field_group:Group title}</code><br/><br/>
-    Fields may be included using <code>{field:field_key}</code><br/><code>{field:field_name}</code>',
+    Fields may be included using <code>{field:field_key}</code><br/><code>{field:field_name}</code>', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -305,10 +305,10 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_html_after_fields',
-            'label' => 'HTML After render',
+            'label' => __('HTML After render', 'acfe'),
             'name' => 'acfe_form_html_after_fields',
             'type' => 'acfe_code_editor',
-            'instructions' => 'Extra HTML to add after the fields',
+            'instructions' => __('Extra HTML to add after the fields', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -324,10 +324,10 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_form_submit',
-            'label' => 'Submit button',
+            'label' => __('Submit button', 'acfe'),
             'name' => 'acfe_form_form_submit',
             'type' => 'true_false',
-            'instructions' => 'Whether or not to create a form submit button. Defaults to true',
+            'instructions' => __('Whether or not to create a form submit button. Defaults to true', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -344,10 +344,10 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_submit_value',
-            'label' => 'Submit value',
+            'label' => __('Submit value', 'acfe'),
             'name' => 'acfe_form_submit_value',
             'type' => 'text',
-            'instructions' => 'The text displayed on the submit button',
+            'instructions' => __('The text displayed on the submit button', 'acfe'),
             'required' => 0,
             'conditional_logic' => array(
                 array(
@@ -364,7 +364,7 @@ acf_add_local_field_group(array(
                 'id' => '',
             ),
             'acfe_permissions' => '',
-            'default_value' => 'Submit',
+            'default_value' => __('Submit', 'acfe'),
             'placeholder' => '',
             'prepend' => '',
             'append' => '',
@@ -372,10 +372,10 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_html_submit_button',
-            'label' => 'Submit button',
+            'label' => __('Submit button', 'acfe'),
             'name' => 'acfe_form_html_submit_button',
             'type' => 'acfe_code_editor',
-            'instructions' => 'HTML used to render the submit button.',
+            'instructions' => __('HTML used to render the submit button.', 'acfe'),
             'required' => 0,
             'conditional_logic' => array(
                 array(
@@ -399,10 +399,10 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_html_submit_spinner',
-            'label' => 'Submit spinner',
+            'label' => __('Submit spinner', 'acfe'),
             'name' => 'acfe_form_html_submit_spinner',
             'type' => 'acfe_code_editor',
-            'instructions' => 'HTML used to render the submit button loading spinner.',
+            'instructions' => __('HTML used to render the submit button loading spinner.', 'acfe'),
             'required' => 0,
             'conditional_logic' => array(
                 array(
@@ -426,7 +426,7 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_tab_submission',
-            'label' => 'Submission',
+            'label' => __('Submission', 'acfe'),
             'name' => '',
             'type' => 'tab',
             'instructions' => '',
@@ -443,10 +443,10 @@ acf_add_local_field_group(array(
         ),
         array(
 			'key' => 'field_acfe_form_hide_error',
-			'label' => 'Hide general error',
+			'label' => __('Hide general error', 'acfe'),
 			'name' => 'acfe_form_hide_error',
 			'type' => 'true_false',
-			'instructions' => 'Hide the general error message: "Validation failed. 1 field requires attention"',
+			'instructions' => __('Hide the general error message: "Validation failed. 1 field requires attention"', 'acfe'),
 			'required' => 0,
 			'conditional_logic' => 0,
 			'wrapper' => array(
@@ -463,10 +463,10 @@ acf_add_local_field_group(array(
 		),
         array(
 			'key' => 'field_acfe_form_hide_unload',
-			'label' => 'Hide confirmation on exit',
+			'label' => __('Hide confirmation on exit', 'acfe'),
 			'name' => 'acfe_form_hide_unload',
 			'type' => 'true_false',
-			'instructions' => 'Do not prompt user on page refresh',
+			'instructions' => __('Do not prompt user on page refresh', 'acfe'),
 			'required' => 0,
 			'conditional_logic' => 0,
 			'wrapper' => array(
@@ -483,10 +483,10 @@ acf_add_local_field_group(array(
 		),
         array(
             'key' => 'field_acfe_form_errors_position',
-            'label' => 'Fields errors position',
+            'label' => __('Fields errors position', 'acfe'),
             'name' => 'acfe_form_errors_position',
             'type' => 'radio',
-            'instructions' => 'Choose where to display field errors',
+            'instructions' => __('Choose where to display field errors', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -510,10 +510,10 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_errors_class',
-            'label' => 'Fields errors class',
+            'label' => __('Fields errors class', 'acfe'),
             'name' => 'acfe_form_errors_class',
             'type' => 'text',
-            'instructions' => 'Add class to error message',
+            'instructions' => __('Add class to error message', 'acfe'),
             'required' => 0,
             'conditional_logic' => array(
                 array(
@@ -544,10 +544,10 @@ acf_add_local_field_group(array(
         
         array(
             'key' => 'field_acfe_form_updated_message',
-            'label' => 'Success message',
+            'label' => __('Success message', 'acfe'),
             'name' => 'acfe_form_updated_message',
             'type' => 'wysiwyg',
-            'instructions' => 'A message displayed above the form after being redirected. Can also be empty for no message.<br /><br />You may use <code>{field:field_name}</code> or <code>{field:field_key}</code> template tags.',
+            'instructions' => __('A message displayed above the form after being redirected. Can also be empty for no message.<br /><br />You may use <code>{field:field_name}</code> or <code>{field:field_key}</code> template tags.', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -556,7 +556,7 @@ acf_add_local_field_group(array(
                 'id' => '',
             ),
             'acfe_permissions' => '',
-            'default_value' => __('Post updated', 'acf'),
+            'default_value' => __('Post updated', 'acfe'),
             'tabs' => 'all',
             'toolbar' => 'full',
             'media_upload' => 1,
@@ -564,11 +564,11 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_html_updated_message',
-            'label' => 'Success wrapper HTML',
+            'label' => __('Success wrapper HTML', 'acfe'),
             'name' => 'acfe_form_html_updated_message',
             'type' => 'acfe_code_editor',
-            'instructions' => 'HTML used to render the updated message.<br /><br />
-    If used, you have to include the following code <code>%s</code> to print the actual \'Success message\' above.',
+            'instructions' => __('HTML used to render the updated message.<br /><br />
+    If used, you have to include the following code <code>%s</code> to print the actual \'Success message\' above.', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -584,10 +584,10 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_updated_hide_form',
-            'label' => 'Hide form',
+            'label' => __('Hide form', 'acfe'),
             'name' => 'acfe_form_updated_hide_form',
             'type' => 'true_false',
-            'instructions' => 'Hide form on successful submission',
+            'instructions' => __('Hide form on successful submission', 'acfe'),
             'required' => 0,
             'conditional_logic' => array(),
             'wrapper' => array(
@@ -604,12 +604,12 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_return',
-            'label' => 'Redirection',
+            'label' => __('Redirection', 'acfe'),
             'name' => 'acfe_form_return',
             'type' => 'text',
-            'instructions' => 'The URL to be redirected to after the form is submit. Defaults to the current URL.<br /><br />
+            'instructions' => __('The URL to be redirected to after the form is submit. Defaults to the current URL.<br /><br />
     A special placeholder <code>%post_url%</code> will be converted to post\'s permalink (handy if creating a new post)<br /><br />
-    A special placeholder <code>%post_id%</code> will be converted to post\'s ID (handy if creating a new post)<br />',
+    A special placeholder <code>%post_id%</code> will be converted to post\'s ID (handy if creating a new post)<br />', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -626,7 +626,7 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_tab_actions',
-            'label' => 'Actions',
+            'label' => __('Actions', 'acfe'),
             'name' => '',
             'type' => 'tab',
             'instructions' => '',
@@ -643,7 +643,7 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_actions',
-            'label' => 'Actions',
+            'label' => __('Actions', 'acfe'),
             'name' => 'acfe_form_actions',
             'type' => 'flexible_content',
             'instructions' => '',
@@ -676,15 +676,15 @@ acf_add_local_field_group(array(
                 'layout_custom' => array(
                     'key' => 'layout_custom',
                     'name' => 'custom',
-                    'label' => 'Custom action',
+                    'label' => __('Custom action', 'acfe'),
                     'display' => 'row',
                     'sub_fields' => array(
                         array(
                             'key' => 'field_acfe_form_custom_action',
-                            'label' => 'Action name',
+                            'label' => __('Action name', 'acfe'),
                             'name' => 'acfe_form_custom_action',
                             'type' => 'acfe_slug',
-                            'instructions' => 'Use the following hook:<br /><code>action(\'acfe/form/submit/my-custom-action\', $form, $current_post_id)</code>',
+                            'instructions' => __('Use the following hook:<br /><code>action(\'acfe/form/submit/my-custom-action\', $form, $current_post_id)</code>', 'acfe'),
                             'required' => 1,
                             'conditional_logic' => 0,
                             'wrapper' => array(
@@ -710,12 +710,12 @@ acf_add_local_field_group(array(
                 'layout_email' => array(
                     'key' => 'layout_email',
                     'name' => 'email',
-                    'label' => 'Email action',
+                    'label' => __('Email action', 'acfe'),
                     'display' => 'row',
                     'sub_fields' => array(
                         array(
                             'key' => 'field_acfe_form_email_instructions',
-                            'label' => 'Instructions',
+                            'label' => __('Instructions', 'acfe'),
                             'name' => '',
                             'type' => 'message',
                             'instructions' => '',
@@ -727,14 +727,14 @@ acf_add_local_field_group(array(
                                 'id' => '',
                             ),
                             'acfe_permissions' => '',
-                            'message' => 'Fields may be included using <code>{field:field_key}</code> or <code>{field:title}</code>.<br />
-    All fields may be included using <code>{fields}</code>.',
+                            'message' => __('Fields may be included using <code>{field:field_key}</code> or <code>{field:title}</code>.<br />
+    All fields may be included using <code>{fields}</code>.', 'acfe'),
                             'new_lines' => '',
                             'esc_html' => 0,
                         ),
                         array(
                             'key' => 'field_acfe_form_email_custom_alias',
-                            'label' => 'Action alias',
+                            'label' => __('Action alias', 'acfe'),
                             'name' => 'acfe_form_custom_alias',
                             'type' => 'acfe_slug',
                             'instructions' => '',
@@ -754,7 +754,7 @@ acf_add_local_field_group(array(
                         ),
                         array(
                             'key' => 'field_acfe_form_email_from',
-                            'label' => 'From',
+                            'label' => __('From', 'acfe'),
                             'name' => 'acfe_form_email_from',
                             'type' => 'text',
                             'instructions' => '',
@@ -767,14 +767,14 @@ acf_add_local_field_group(array(
                             ),
                             'acfe_permissions' => '',
                             'default_value' => '',
-                            'placeholder' => 'Name <email@domain.com>',
+                            'placeholder' => __('Name', 'acfe') . '<email@domain.com>',
                             'prepend' => '',
                             'append' => '',
                             'maxlength' => '',
                         ),
                         array(
                             'key' => 'field_acfe_form_email_to',
-                            'label' => 'To',
+                            'label' => __('To', 'acfe'),
                             'name' => 'acfe_form_email_to',
                             'type' => 'text',
                             'instructions' => '',
@@ -793,7 +793,7 @@ acf_add_local_field_group(array(
                         ),
                         array(
                             'key' => 'field_acfe_form_email_subject',
-                            'label' => 'Subject',
+                            'label' => __('Subject', 'acfe'),
                             'name' => 'acfe_form_email_subject',
                             'type' => 'text',
                             'instructions' => '',
@@ -813,7 +813,7 @@ acf_add_local_field_group(array(
                         ),
                         array(
                             'key' => 'field_acfe_form_email_content',
-                            'label' => 'Content',
+                            'label' => __('Content', 'acfe'),
                             'name' => 'acfe_form_email_content',
                             'type' => 'wysiwyg',
                             'instructions' => '',
@@ -833,7 +833,7 @@ acf_add_local_field_group(array(
                         ),
                         array(
                             'key' => 'field_acfe_form_email_files',
-                            'label' => 'Attachments',
+                            'label' => __('Attachments', 'acfe'),
                             'name' => 'acfe_form_email_files',
                             'type' => 'repeater',
                             'instructions' => '',
@@ -850,11 +850,11 @@ acf_add_local_field_group(array(
                             'min' => 0,
                             'max' => 0,
                             'layout' => 'table',
-                            'button_label' => 'Add file',
+                            'button_label' => __('Add file', 'acfe'),
                             'sub_fields' => array(
                                 array(
                                     'key' => 'field_acfe_form_email_file',
-                                    'label' => 'File',
+                                    'label' => __('File', 'acfe'),
                                     'name' => 'acfe_form_email_file',
                                     'type' => 'select',
                                     'instructions' => '',
@@ -1023,12 +1023,12 @@ acf_add_local_field_group(array(
 				'layout_post' => array(
 					'key' => 'layout_post',
 					'name' => 'post',
-					'label' => 'Post action',
+					'label' => __('Post action', 'acfe'),
 					'display' => 'row',
 					'sub_fields' => array(
 						array(
 							'key' => 'field_acfe_form_post_tab_save',
-							'label' => 'Save',
+							'label' => __('Save', 'acfe'),
 							'name' => '',
 							'type' => 'tab',
 							'instructions' => '',
@@ -1045,7 +1045,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_action',
-							'label' => 'Action',
+							'label' => __('Action', 'acfe'),
 							'name' => 'acfe_form_post_action',
 							'type' => 'radio',
 							'instructions' => '',
@@ -1058,8 +1058,8 @@ acf_add_local_field_group(array(
 							),
 							'acfe_permissions' => '',
 							'choices' => array(
-								'insert_post' => 'Create post',
-								'update_post' => 'Update post',
+								'insert_post' => __('Create post', 'acfe'),
+								'update_post' => __('Update post', 'acfe'),
 							),
 							'allow_null' => 0,
 							'other_choice' => 0,
@@ -1070,7 +1070,7 @@ acf_add_local_field_group(array(
 						),
                         array(
                             'key' => 'field_acfe_form_post_custom_alias',
-                            'label' => 'Action alias',
+                            'label' => __('Action alias', 'acfe'),
                             'name' => 'acfe_form_custom_alias',
                             'type' => 'acfe_slug',
                             'instructions' => '',
@@ -1090,7 +1090,7 @@ acf_add_local_field_group(array(
                         ),
 						array(
 							'key' => 'field_acfe_form_post_save_target',
-							'label' => 'Target',
+							'label' => __('Target', 'acfe'),
 							'name' => 'acfe_form_post_save_target',
 							'type' => 'select',
 							'instructions' => '',
@@ -1124,7 +1124,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_save_post_type',
-							'label' => 'Post type',
+							'label' => __('Post type', 'acfe'),
 							'name' => 'acfe_form_post_save_post_type',
 							'type' => 'acfe_post_types',
 							'instructions' => '',
@@ -1160,7 +1160,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_map_post_type_message',
-							'label' => 'Post type',
+							'label' => __('Post type', 'acfe'),
 							'name' => 'acfe_form_post_map_post_type_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -1182,7 +1182,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_save_post_status',
-							'label' => 'Post status',
+							'label' => __('Post status', 'acfe'),
 							'name' => 'acfe_form_post_save_post_status',
 							'type' => 'acfe_post_statuses',
 							'instructions' => '',
@@ -1218,7 +1218,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_map_post_status_message',
-							'label' => 'Post status',
+							'label' => __('Post status', 'acfe'),
 							'name' => 'acfe_form_post_map_post_status_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -1240,7 +1240,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_save_post_title_group',
-							'label' => 'Post title',
+							'label' => __('Post title', 'acfe'),
 							'name' => 'acfe_form_post_save_post_title_group',
 							'type' => 'group',
 							'instructions' => '',
@@ -1278,8 +1278,8 @@ acf_add_local_field_group(array(
 									),
 									'acfe_permissions' => '',
 									'choices' => array(
-										'generated_id' => 'Generated ID',
-										'custom' => 'Custom title',
+										'generated_id' => __('Generated ID', 'acfe'),
+										'custom' => __('Custom title', 'acfe'),
 									),
 									'default_value' => array(
 									),
@@ -1313,7 +1313,7 @@ acf_add_local_field_group(array(
 									),
 									'acfe_permissions' => '',
 									'default_value' => '',
-									'placeholder' => 'Available tag: {field:name} *',
+									'placeholder' => __('Available tag:', 'acfe') . ' {field:name} *',
 									'prepend' => '',
 									'append' => '',
 									'maxlength' => '',
@@ -1322,7 +1322,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_map_post_title_message',
-							'label' => 'Post title',
+							'label' => __('Post title', 'acfe'),
 							'name' => 'acfe_form_post_map_post_title_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -1344,7 +1344,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_save_post_name_group',
-							'label' => 'Post slug',
+							'label' => __('Post slug', 'acfe'),
 							'name' => 'acfe_form_post_save_post_name_group',
 							'type' => 'group',
 							'instructions' => '',
@@ -1426,7 +1426,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_map_post_name_message',
-							'label' => 'Post slug',
+							'label' => __('Post slug', 'acfe'),
 							'name' => 'acfe_form_post_map_post_name_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -1448,7 +1448,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_save_post_content_group',
-							'label' => 'Post content',
+							'label' => __('Post content', 'acfe'),
 							'name' => 'acfe_form_post_save_post_content_group',
 							'type' => 'group',
 							'instructions' => '',
@@ -1486,7 +1486,7 @@ acf_add_local_field_group(array(
 									),
 									'acfe_permissions' => '',
 									'choices' => array(
-										'custom' => 'Custom content',
+										'custom' => __('Custom content', 'acfe'),
 									),
 									'default_value' => array(
 									),
@@ -1529,7 +1529,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_map_post_content_message',
-							'label' => 'Post content',
+							'label' => __('Post content', 'acfe'),
 							'name' => 'acfe_form_post_map_post_content_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -1551,7 +1551,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_save_post_author',
-							'label' => 'Post author',
+							'label' => __('Post author', 'acfe'),
 							'name' => 'acfe_form_post_save_post_author',
 							'type' => 'select',
 							'instructions' => '',
@@ -1583,7 +1583,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_map_post_author_message',
-							'label' => 'Post author',
+							'label' => __('Post author', 'acfe'),
 							'name' => 'acfe_form_post_map_post_author_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -1605,7 +1605,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_save_post_parent',
-							'label' => 'Post parent',
+							'label' => __('Post parent', 'acfe'),
 							'name' => 'acfe_form_post_save_post_parent',
 							'type' => 'select',
 							'instructions' => '',
@@ -1637,7 +1637,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_map_post_parent_message',
-							'label' => 'Post parent',
+							'label' => __('Post parent', 'acfe'),
 							'name' => 'acfe_form_post_map_post_parent_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -1659,7 +1659,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_save_post_terms',
-							'label' => 'Post terms',
+							'label' => __('Post terms', 'acfe'),
 							'name' => 'acfe_form_post_save_post_terms',
 							'type' => 'acfe_taxonomy_terms',
 							'instructions' => '',
@@ -1695,7 +1695,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_map_post_terms_message',
-							'label' => 'Post terms',
+							'label' => __('Post terms', 'acfe'),
 							'name' => 'acfe_form_post_map_post_terms_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -1717,10 +1717,10 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_save_meta',
-							'label' => 'Save Meta fields',
+							'label' => __('Save Meta fields', 'acfe'),
 							'name' => 'acfe_form_post_save_meta',
 							'type' => 'checkbox',
-							'instructions' => 'Choose which ACF fields should be saved to this post',
+							'instructions' => __('Choose which ACF fields should be saved to this post', 'acfe'),
 							'required' => 0,
 							'conditional_logic' => 0,
 							'wrapper' => array(
@@ -1741,7 +1741,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'acfe_form_post_tab_load',
-							'label' => 'Load',
+							'label' => __('Load', 'acfe'),
 							'name' => '',
 							'type' => 'tab',
 							'instructions' => '',
@@ -1758,10 +1758,10 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_load_values',
-							'label' => 'Load Values',
+							'label' => __('Load Values', 'acfe'),
 							'name' => 'acfe_form_post_load_values',
 							'type' => 'true_false',
-							'instructions' => 'Fill inputs with values',
+							'instructions' => __('Fill inputs with values', 'acfe'),
 							'required' => 0,
 							'conditional_logic' => 0,
 							'wrapper' => array(
@@ -1778,7 +1778,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_load_source',
-							'label' => 'Values Source',
+							'label' => __('Values Source', 'acfe'),
 							'name' => 'acfe_form_post_load_source',
 							'type' => 'select',
 							'instructions' => '',
@@ -1812,10 +1812,10 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_load_meta',
-							'label' => 'Fields Values',
+							'label' => __('Fields Values', 'acfe'),
 							'name' => 'acfe_form_post_load_meta',
 							'type' => 'checkbox',
-							'instructions' => 'Choose which ACF fields should have values filled',
+							'instructions' => __('Choose which ACF fields should have values filled', 'acfe'),
 							'required' => 0,
 							'conditional_logic' => array(
 								array(
@@ -1844,7 +1844,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'acfe_form_post_tab_mapping',
-							'label' => 'Mapping',
+							'label' => __('Mapping', 'acfe'),
 							'name' => '',
 							'type' => 'tab',
 							'instructions' => '',
@@ -1861,7 +1861,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_map_post_type',
-							'label' => 'Post type',
+							'label' => __('Post type', 'acfe'),
 							'name' => 'acfe_form_post_map_post_type',
 							'type' => 'select',
 							'instructions' => '',
@@ -1886,7 +1886,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_map_post_status',
-							'label' => 'Post status',
+							'label' => __('Post status', 'acfe'),
 							'name' => 'acfe_form_post_map_post_status',
 							'type' => 'select',
 							'instructions' => '',
@@ -1911,7 +1911,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_map_post_title',
-							'label' => 'Post title',
+							'label' => __('Post title', 'acfe'),
 							'name' => 'acfe_form_post_map_post_title',
 							'type' => 'select',
 							'instructions' => '',
@@ -1936,7 +1936,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_map_post_name',
-							'label' => 'Post slug',
+							'label' => __('Post slug', 'acfe'),
 							'name' => 'acfe_form_post_map_post_name',
 							'type' => 'select',
 							'instructions' => '',
@@ -1961,7 +1961,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_map_post_content',
-							'label' => 'Post content',
+							'label' => __('Post content', 'acfe'),
 							'name' => 'acfe_form_post_map_post_content',
 							'type' => 'select',
 							'instructions' => '',
@@ -1986,7 +1986,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_map_post_author',
-							'label' => 'Post author',
+							'label' => __('Post author', 'acfe'),
 							'name' => 'acfe_form_post_map_post_author',
 							'type' => 'select',
 							'instructions' => '',
@@ -2011,7 +2011,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_map_post_parent',
-							'label' => 'Post parent',
+							'label' => __('Post parent', 'acfe'),
 							'name' => 'acfe_form_post_map_post_parent',
 							'type' => 'select',
 							'instructions' => '',
@@ -2036,7 +2036,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_post_map_post_terms',
-							'label' => 'Post terms',
+							'label' => __('Post terms', 'acfe'),
 							'name' => 'acfe_form_post_map_post_terms',
 							'type' => 'select',
 							'instructions' => '',
@@ -2061,7 +2061,7 @@ acf_add_local_field_group(array(
 						),
                         array(
 							'key' => 'field_acfe_form_post_tab_advanced',
-							'label' => 'Advanced',
+							'label' => __('Advanced', 'acfe'),
 							'name' => '',
 							'type' => 'tab',
 							'instructions' => '',
@@ -2078,11 +2078,11 @@ acf_add_local_field_group(array(
 						),
                         array(
                             'key' => 'field_acfe_form_post_advanced_load',
-                            'label' => 'Change values source',
+                            'label' => __('Change values source', 'acfe'),
                             'name' => 'acfe_form_post_advanced_load',
                             'type' => 'acfe_dynamic_message',
                             'value' => isset($_REQUEST['post']) ? $_REQUEST['post'] : '',
-                            'instructions' => 'Dynamically alter the post ID where meta values are loaded from',
+                            'instructions' => __('Dynamically alter the post ID where meta values are loaded from', 'acfe'),
                             'required' => 0,
                             'conditional_logic' => 0,
                             'wrapper' => array(
@@ -2094,11 +2094,11 @@ acf_add_local_field_group(array(
                         ),
                         array(
                             'key' => 'field_acfe_form_post_advanced_save_args',
-                            'label' => 'Change post arguments',
+                            'label' => __('Change post arguments', 'acfe'),
                             'name' => 'acfe_form_post_advanced_save_args',
                             'type' => 'acfe_dynamic_message',
                             'value' => isset($_REQUEST['post']) ? $_REQUEST['post'] : '',
-                            'instructions' => 'Dynamically alter the post arguments before database insert/update',
+                            'instructions' => __('Dynamically alter the post arguments before database insert/update', 'acfe'),
                             'required' => 0,
                             'conditional_logic' => 0,
                             'wrapper' => array(
@@ -2110,11 +2110,11 @@ acf_add_local_field_group(array(
                         ),
                         array(
                             'key' => 'field_acfe_form_post_advanced_save',
-                            'label' => 'Add custom action on post save',
+                            'label' => __('Add custom action on post save', 'acfe'),
                             'name' => 'acfe_form_post_advanced_save',
                             'type' => 'acfe_dynamic_message',
                             'value' => isset($_REQUEST['post']) ? $_REQUEST['post'] : '',
-                            'instructions' => 'This action allows you to hook in before or after the meta data have been saved',
+                            'instructions' => __('This action allows you to hook in before or after the meta data have been saved', 'acfe'),
                             'required' => 0,
                             'conditional_logic' => 0,
                             'wrapper' => array(
@@ -2135,12 +2135,12 @@ acf_add_local_field_group(array(
 				'layout_term' => array(
 					'key' => 'layout_term',
 					'name' => 'term',
-					'label' => 'Term action',
+					'label' => __('Term action', 'acfe'),
 					'display' => 'row',
 					'sub_fields' => array(
 						array(
 							'key' => 'field_acfe_form_term_tab_save',
-							'label' => 'Save',
+							'label' => __('Save', 'acfe'),
 							'name' => '',
 							'type' => 'tab',
 							'instructions' => '',
@@ -2157,7 +2157,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'acfe_form_term_action',
-							'label' => 'Action',
+							'label' => __('Action', 'acfe'),
 							'name' => 'acfe_form_term_action',
 							'type' => 'radio',
 							'instructions' => '',
@@ -2170,8 +2170,8 @@ acf_add_local_field_group(array(
 							),
 							'acfe_permissions' => '',
 							'choices' => array(
-								'insert_term' => 'Create term',
-								'update_term' => 'Update term',
+								'insert_term' => __('Create term', 'acfe'),
+								'update_term' => __('Update term', 'acfe'),
 							),
 							'allow_null' => 0,
 							'other_choice' => 0,
@@ -2182,7 +2182,7 @@ acf_add_local_field_group(array(
 						),
                         array(
                             'key' => 'field_acfe_form_term_custom_alias',
-                            'label' => 'Action alias',
+                            'label' => __('Action alias', 'acfe'),
                             'name' => 'acfe_form_custom_alias',
                             'type' => 'acfe_slug',
                             'instructions' => '',
@@ -2202,7 +2202,7 @@ acf_add_local_field_group(array(
                         ),
 						array(
 							'key' => 'field_acfe_form_term_save_target',
-							'label' => 'Target',
+							'label' => __('Target', 'acfe'),
 							'name' => 'acfe_form_term_save_target',
 							'type' => 'select',
 							'instructions' => '',
@@ -2236,7 +2236,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_save_name_group',
-							'label' => 'Name',
+							'label' => __('Name', 'acfe'),
 							'name' => 'acfe_form_term_save_name_group',
 							'type' => 'group',
 							'instructions' => '',
@@ -2317,7 +2317,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_map_name_message',
-							'label' => 'Name',
+							'label' => __('Name', 'acfe'),
 							'name' => 'acfe_form_term_map_name_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -2339,7 +2339,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_save_slug_group',
-							'label' => 'Slug',
+							'label' => __('Slug', 'acfe'),
 							'name' => 'acfe_form_term_save_slug_group',
 							'type' => 'group',
 							'instructions' => '',
@@ -2411,7 +2411,7 @@ acf_add_local_field_group(array(
 									),
 									'acfe_permissions' => '',
 									'default_value' => '',
-									'placeholder' => 'Available tag: {field:name} *',
+									'placeholder' => __('Available tag:', 'acfe') . ' {field:name} *',
 									'prepend' => '',
 									'append' => '',
 									'maxlength' => '',
@@ -2420,7 +2420,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_map_slug_message',
-							'label' => 'Slug',
+							'label' => __('Slug', 'acfe'),
 							'name' => 'acfe_form_term_map_slug_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -2442,7 +2442,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_save_taxonomy',
-							'label' => 'Taxonomy',
+							'label' => __('Taxonomy', 'acfe'),
 							'name' => 'acfe_form_term_save_taxonomy',
 							'type' => 'acfe_taxonomies',
 							'instructions' => '',
@@ -2478,7 +2478,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_map_taxonomy_message',
-							'label' => 'Taxonomy',
+							'label' => __('Taxonomy', 'acfe'),
 							'name' => 'acfe_form_term_map_taxonomy_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -2500,7 +2500,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_save_parent',
-							'label' => 'Parent',
+							'label' => __('Parent', 'acfe'),
 							'name' => 'acfe_form_term_save_parent',
 							'type' => 'select',
 							'instructions' => '',
@@ -2532,7 +2532,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_map_parent_message',
-							'label' => 'Parent',
+							'label' => __('Parent', 'acfe'),
 							'name' => 'acfe_form_term_map_parent_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -2554,7 +2554,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_save_description_group',
-							'label' => 'Description',
+							'label' => __('Description', 'acfe'),
 							'name' => 'acfe_form_term_save_description_group',
 							'type' => 'group',
 							'instructions' => '',
@@ -2635,7 +2635,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_map_description_message',
-							'label' => 'Description',
+							'label' => __('Description', 'acfe'),
 							'name' => 'acfe_form_term_map_description_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -2657,10 +2657,10 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_save_meta',
-							'label' => 'Save Meta fields',
+							'label' => __('Save Meta fields', 'acfe'),
 							'name' => 'acfe_form_term_save_meta',
 							'type' => 'checkbox',
-							'instructions' => 'Choose which ACF fields should be saved to this term',
+							'instructions' => __('Choose which ACF fields should be saved to this term', 'acfe'),
 							'required' => 0,
 							'conditional_logic' => 0,
 							'wrapper' => array(
@@ -2681,7 +2681,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_tab_load',
-							'label' => 'Load',
+							'label' => __('Load', 'acfe'),
 							'name' => '',
 							'type' => 'tab',
 							'instructions' => '',
@@ -2698,10 +2698,10 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_load_values',
-							'label' => 'Load Values',
+							'label' => __('Load Values', 'acfe'),
 							'name' => 'acfe_form_term_load_values',
 							'type' => 'true_false',
-							'instructions' => 'Fill inputs with values',
+							'instructions' => __('Fill inputs with values', 'acfe'),
 							'required' => 0,
 							'conditional_logic' => 0,
 							'wrapper' => array(
@@ -2718,7 +2718,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_load_source',
-							'label' => 'Values Source',
+							'label' => __('Values Source', 'acfe'),
 							'name' => 'acfe_form_term_load_source',
 							'type' => 'select',
 							'instructions' => '',
@@ -2752,10 +2752,10 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_load_meta',
-							'label' => 'Fields Values',
+							'label' => __('Fields Values', 'acfe'),
 							'name' => 'acfe_form_term_load_meta',
 							'type' => 'checkbox',
-							'instructions' => 'Choose which ACF fields should have values filled',
+							'instructions' => __('Choose which ACF fields should have values filled', 'acfe'),
 							'required' => 0,
 							'conditional_logic' => array(
 								array(
@@ -2784,7 +2784,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_tab_mapping',
-							'label' => 'Mapping',
+							'label' => __('Mapping', 'acfe'),
 							'name' => '',
 							'type' => 'tab',
 							'instructions' => '',
@@ -2801,7 +2801,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_map_name',
-							'label' => 'Name',
+							'label' => __('Name', 'acfe'),
 							'name' => 'acfe_form_term_map_name',
 							'type' => 'select',
 							'instructions' => '',
@@ -2826,7 +2826,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_map_slug',
-							'label' => 'Slug',
+							'label' => __('Slug', 'acfe'),
 							'name' => 'acfe_form_term_map_slug',
 							'type' => 'select',
 							'instructions' => '',
@@ -2851,7 +2851,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_map_taxonomy',
-							'label' => 'Taxonomy',
+							'label' => __('Taxonomy', 'acfe'),
 							'name' => 'acfe_form_term_map_taxonomy',
 							'type' => 'select',
 							'instructions' => '',
@@ -2876,7 +2876,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_map_parent',
-							'label' => 'Parent',
+							'label' => __('Parent', 'acfe'),
 							'name' => 'acfe_form_term_map_parent',
 							'type' => 'select',
 							'instructions' => '',
@@ -2901,7 +2901,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_term_map_description',
-							'label' => 'Description',
+							'label' => __('Description', 'acfe'),
 							'name' => 'acfe_form_term_map_description',
 							'type' => 'select',
 							'instructions' => '',
@@ -2926,7 +2926,7 @@ acf_add_local_field_group(array(
 						),
                         array(
 							'key' => 'field_acfe_form_term_tab_advanced',
-							'label' => 'Advanced',
+							'label' => __('Advanced', 'acfe'),
 							'name' => '',
 							'type' => 'tab',
 							'instructions' => '',
@@ -2943,11 +2943,11 @@ acf_add_local_field_group(array(
 						),
                         array(
                             'key' => 'field_acfe_form_term_advanced_load',
-                            'label' => 'Change values source',
+                            'label' => __('Change values source', 'acfe'),
                             'name' => 'acfe_form_term_advanced_load',
                             'type' => 'acfe_dynamic_message',
                             'value' => isset($_REQUEST['post']) ? $_REQUEST['post'] : '',
-                            'instructions' => 'Dynamically alter the term ID where meta values are loaded from',
+                            'instructions' => __('Dynamically alter the term ID where meta values are loaded from', 'acfe'),
                             'required' => 0,
                             'conditional_logic' => 0,
                             'wrapper' => array(
@@ -2959,11 +2959,11 @@ acf_add_local_field_group(array(
                         ),
                         array(
                             'key' => 'field_acfe_form_term_advanced_save_args',
-                            'label' => 'Change term arguments',
+                            'label' => __('Change term arguments', 'acfe'),
                             'name' => 'acfe_form_term_advanced_save_args',
                             'type' => 'acfe_dynamic_message',
                             'value' => isset($_REQUEST['post']) ? $_REQUEST['post'] : '',
-                            'instructions' => 'Dynamically alter the term arguments before database insert/update',
+                            'instructions' => __('Dynamically alter the term arguments before database insert/update', 'acfe'),
                             'required' => 0,
                             'conditional_logic' => 0,
                             'wrapper' => array(
@@ -2975,11 +2975,11 @@ acf_add_local_field_group(array(
                         ),
                         array(
                             'key' => 'field_acfe_form_term_advanced_save',
-                            'label' => 'Add custom action on term save',
+                            'label' => __('Add custom action on term save', 'acfe'),
                             'name' => 'acfe_form_term_advanced_save',
                             'type' => 'acfe_dynamic_message',
                             'value' => isset($_REQUEST['post']) ? $_REQUEST['post'] : '',
-                            'instructions' => 'This action allows you to hook in before or after the meta data have been saved',
+                            'instructions' => __('This action allows you to hook in before or after the meta data have been saved', 'acfe'),
                             'required' => 0,
                             'conditional_logic' => 0,
                             'wrapper' => array(
@@ -3000,12 +3000,12 @@ acf_add_local_field_group(array(
 				'layout_user' => array(
 					'key' => 'layout_user',
 					'name' => 'user',
-					'label' => 'User action',
+					'label' => , __('User action', 'acfe'),
 					'display' => 'row',
 					'sub_fields' => array(
 						array(
 							'key' => 'field_acfe_form_user_tab_save',
-							'label' => 'Save',
+							'label' => __('Save', 'acfe'),
 							'name' => '',
 							'type' => 'tab',
 							'instructions' => '',
@@ -3022,7 +3022,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_action',
-							'label' => 'Action',
+							'label' => __('Action', 'acfe'),
 							'name' => 'acfe_form_user_action',
 							'type' => 'radio',
 							'instructions' => '',
@@ -3035,8 +3035,8 @@ acf_add_local_field_group(array(
 							),
 							'acfe_permissions' => '',
 							'choices' => array(
-								'insert_user' => 'Create user',
-								'update_user' => 'Update user',
+								'insert_user' => __('Create user', 'acfe'),
+								'update_user' => __('Update user', 'acfe'),
 							),
 							'allow_null' => 0,
 							'other_choice' => 0,
@@ -3047,7 +3047,7 @@ acf_add_local_field_group(array(
 						),
                         array(
                             'key' => 'field_acfe_form_user_custom_alias',
-                            'label' => 'Action alias',
+                            'label' => __('Action alias', 'acfe'),
                             'name' => 'acfe_form_custom_alias',
                             'type' => 'acfe_slug',
                             'instructions' => '',
@@ -3067,7 +3067,7 @@ acf_add_local_field_group(array(
                         ),
 						array(
 							'key' => 'field_acfe_form_user_save_target',
-							'label' => 'Target',
+							'label' => __('Target', 'acfe'),
 							'name' => 'acfe_form_user_save_target',
 							'type' => 'select',
 							'instructions' => '',
@@ -3101,7 +3101,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_save_email_group',
-							'label' => 'Email',
+							'label' => __('Email', 'acfe'),
 							'name' => 'acfe_form_user_save_email_group',
 							'type' => 'group',
 							'instructions' => '',
@@ -3173,7 +3173,7 @@ acf_add_local_field_group(array(
 									),
 									'acfe_permissions' => '',
 									'default_value' => '',
-									'placeholder' => 'Available tag: {field:name} *',
+									'placeholder' => __('Available tag:', 'acfe') . ' {field:name} *',
 									'prepend' => '',
 									'append' => '',
 									'maxlength' => '',
@@ -3182,7 +3182,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_email_message',
-							'label' => 'Email',
+							'label' => __('Email', 'acfe'),
 							'name' => 'acfe_form_user_map_email_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -3204,7 +3204,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_save_username_group',
-							'label' => 'Username',
+							'label' => __('Username', 'acfe'),
 							'name' => 'acfe_form_user_save_username_group',
 							'type' => 'group',
 							'instructions' => '',
@@ -3285,7 +3285,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_username_message',
-							'label' => 'Username',
+							'label' => __('Username', 'acfe'),
 							'name' => 'acfe_form_user_map_username_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -3307,7 +3307,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_save_password_group',
-							'label' => 'Password',
+							'label' => __('Password', 'acfe'),
 							'name' => 'acfe_form_user_save_password_group',
 							'type' => 'group',
 							'instructions' => '',
@@ -3389,7 +3389,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_password_message',
-							'label' => 'Password',
+							'label' => __('Password', 'acfe'),
 							'name' => 'acfe_form_user_map_password_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -3411,7 +3411,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_save_first_name_group',
-							'label' => 'First name',
+							'label' => __('First name', 'acfe'),
 							'name' => 'acfe_form_user_save_first_name_group',
 							'type' => 'group',
 							'instructions' => '',
@@ -3492,7 +3492,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_first_name_message',
-							'label' => 'First name',
+							'label' => __('First name', 'acfe'),
 							'name' => 'acfe_form_user_map_first_name_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -3514,7 +3514,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_save_last_name_group',
-							'label' => 'Last name',
+							'label' => __('Last name', 'acfe'),
 							'name' => 'acfe_form_user_save_last_name_group',
 							'type' => 'group',
 							'instructions' => '',
@@ -3586,7 +3586,7 @@ acf_add_local_field_group(array(
 									),
 									'acfe_permissions' => '',
 									'default_value' => '',
-									'placeholder' => 'Available tag: {field:name} *',
+									'placeholder' => __('Available tag:', 'acfe') . ' {field:name} *',
 									'prepend' => '',
 									'append' => '',
 									'maxlength' => '',
@@ -3595,7 +3595,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_last_name_message',
-							'label' => 'Last name',
+							'label' => __('Last name', 'acfe'),
 							'name' => 'acfe_form_user_map_last_name_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -3617,7 +3617,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_save_nickname_group',
-							'label' => 'Nickname',
+							'label' => __('Nickname', 'acfe'),
 							'name' => 'acfe_form_user_save_nickname_group',
 							'type' => 'group',
 							'instructions' => '',
@@ -3698,7 +3698,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_nickname_message',
-							'label' => 'Nickname',
+							'label' => __('Nickname', 'acfe'),
 							'name' => 'acfe_form_user_map_nickname_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -3720,7 +3720,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_save_display_name_group',
-							'label' => 'Display name',
+							'label' => __('Display name', 'acfe'),
 							'name' => 'acfe_form_user_save_display_name_group',
 							'type' => 'group',
 							'instructions' => '',
@@ -3801,7 +3801,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_display_name_message',
-							'label' => 'Display name',
+							'label' => __('Display name', 'acfe'),
 							'name' => 'acfe_form_user_map_display_name_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -3823,7 +3823,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_save_website_group',
-							'label' => 'Website',
+							'label' => __('Website', 'acfe'),
 							'name' => 'acfe_form_user_save_website_group',
 							'type' => 'group',
 							'instructions' => '',
@@ -3904,7 +3904,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_website_message',
-							'label' => 'Website',
+							'label' => __('Website', 'acfe'),
 							'name' => 'acfe_form_user_map_website_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -3926,7 +3926,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_save_description_group',
-							'label' => 'Description',
+							'label' => __('Description', 'acfe'),
 							'name' => 'acfe_form_user_save_description_group',
 							'type' => 'group',
 							'instructions' => '',
@@ -4007,7 +4007,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_description_message',
-							'label' => 'Description',
+							'label' => __('Description', 'acfe'),
 							'name' => 'acfe_form_user_map_description_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -4029,7 +4029,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_save_role',
-							'label' => 'Role',
+							'label' => __('Role', 'acfe'),
 							'name' => 'acfe_form_user_save_role',
 							'type' => 'acfe_user_roles',
 							'instructions' => '',
@@ -4064,7 +4064,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_role_message',
-							'label' => 'Role',
+							'label' => __('Role', 'acfe'),
 							'name' => 'acfe_form_user_map_role_message',
 							'type' => 'acfe_dynamic_message',
 							'instructions' => '',
@@ -4086,10 +4086,10 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_save_meta',
-							'label' => 'Save Meta fields',
+							'label' => __('Save Meta fields', 'acfe'),
 							'name' => 'acfe_form_user_save_meta',
 							'type' => 'checkbox',
-							'instructions' => 'Choose which ACF fields should be saved to this user',
+							'instructions' => __('Choose which ACF fields should be saved to this user', 'acfe'),
 							'required' => 0,
 							'conditional_logic' => 0,
 							'wrapper' => array(
@@ -4110,7 +4110,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'acfe_form_user_tab_load',
-							'label' => 'Load',
+							'label' => __('Load', 'acfe'),
 							'name' => '',
 							'type' => 'tab',
 							'instructions' => '',
@@ -4127,10 +4127,10 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_load_values',
-							'label' => 'Load Values',
+							'label' => __('Load Values', 'acfe'),
 							'name' => 'acfe_form_user_load_values',
 							'type' => 'true_false',
-							'instructions' => 'Fill inputs with values',
+							'instructions' => __('Fill inputs with values', 'acfe'),
 							'required' => 0,
 							'conditional_logic' => 0,
 							'wrapper' => array(
@@ -4147,7 +4147,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_load_source',
-							'label' => 'Values Source',
+							'label' => __('Values Source', 'acfe'),
 							'name' => 'acfe_form_user_load_source',
 							'type' => 'select',
 							'instructions' => '',
@@ -4181,10 +4181,10 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_load_meta',
-							'label' => 'Fields Values',
+							'label' => __('Fields Values', 'acfe'),
 							'name' => 'acfe_form_user_load_meta',
 							'type' => 'checkbox',
-							'instructions' => 'Choose which ACF fields should have values filled',
+							'instructions' => __('Choose which ACF fields should have values filled', 'acfe'),
 							'required' => 0,
 							'conditional_logic' => array(
 								array(
@@ -4213,7 +4213,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'acfe_form_user_tab_mapping',
-							'label' => 'Mapping',
+							'label' => __('Mapping', 'acfe'),
 							'name' => '',
 							'type' => 'tab',
 							'instructions' => '',
@@ -4230,7 +4230,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_email',
-							'label' => 'Email',
+							'label' => __('Email', 'acfe'),
 							'name' => 'acfe_form_user_map_email',
 							'type' => 'select',
 							'instructions' => '',
@@ -4255,7 +4255,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_username',
-							'label' => 'Username',
+							'label' => __('Username', 'acfe'),
 							'name' => 'acfe_form_user_map_username',
 							'type' => 'select',
 							'instructions' => '',
@@ -4280,7 +4280,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_password',
-							'label' => 'Password',
+							'label' => __('Password', 'acfe'),
 							'name' => 'acfe_form_user_map_password',
 							'type' => 'select',
 							'instructions' => '',
@@ -4305,7 +4305,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_first_name',
-							'label' => 'First name',
+							'label' => __('First name', 'acfe'),
 							'name' => 'acfe_form_user_map_first_name',
 							'type' => 'select',
 							'instructions' => '',
@@ -4330,7 +4330,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_last_name',
-							'label' => 'Last name',
+							'label' => __('Last name', 'acfe'),
 							'name' => 'acfe_form_user_map_last_name',
 							'type' => 'select',
 							'instructions' => '',
@@ -4355,7 +4355,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_nickname',
-							'label' => 'Nickname',
+							'label' => __('Nickname', 'acfe'),
 							'name' => 'acfe_form_user_map_nickname',
 							'type' => 'select',
 							'instructions' => '',
@@ -4380,7 +4380,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_display_name',
-							'label' => 'Display name',
+							'label' => __('Display name', 'acfe'),
 							'name' => 'acfe_form_user_map_display_name',
 							'type' => 'select',
 							'instructions' => '',
@@ -4405,7 +4405,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_website',
-							'label' => 'Website',
+							'label' => __('Website', 'acfe'),
 							'name' => 'acfe_form_user_map_website',
 							'type' => 'select',
 							'instructions' => '',
@@ -4430,7 +4430,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_description',
-							'label' => 'Description',
+							'label' => __('Description', 'acfe'),
 							'name' => 'acfe_form_user_map_description',
 							'type' => 'select',
 							'instructions' => '',
@@ -4455,7 +4455,7 @@ acf_add_local_field_group(array(
 						),
 						array(
 							'key' => 'field_acfe_form_user_map_role',
-							'label' => 'Role',
+							'label' => __('Role', 'acfe'),
 							'name' => 'acfe_form_user_map_role',
 							'type' => 'select',
 							'instructions' => '',
@@ -4480,7 +4480,7 @@ acf_add_local_field_group(array(
 						),
                         array(
 							'key' => 'field_acfe_form_user_tab_advanced',
-							'label' => 'Advanced',
+							'label' => __('Advanced', 'acfe'),
 							'name' => '',
 							'type' => 'tab',
 							'instructions' => '',
@@ -4497,11 +4497,11 @@ acf_add_local_field_group(array(
 						),
                         array(
                             'key' => 'field_acfe_form_user_advanced_load',
-                            'label' => 'Change values source',
+                            'label' => __('Change values source', 'acfe'),
                             'name' => 'acfe_form_user_advanced_load',
                             'type' => 'acfe_dynamic_message',
                             'value' => isset($_REQUEST['post']) ? $_REQUEST['post'] : '',
-                            'instructions' => 'Dynamically alter the user ID where meta values are loaded from',
+                            'instructions' => __('Dynamically alter the user ID where meta values are loaded from', 'acfe'),
                             'required' => 0,
                             'conditional_logic' => 0,
                             'wrapper' => array(
@@ -4513,11 +4513,11 @@ acf_add_local_field_group(array(
                         ),
                         array(
                             'key' => 'field_acfe_form_user_advanced_save_args',
-                            'label' => 'Change user arguments',
+                            'label' => __('Change user arguments', 'acfe'),
                             'name' => 'acfe_form_user_advanced_save_args',
                             'type' => 'acfe_dynamic_message',
                             'value' => isset($_REQUEST['post']) ? $_REQUEST['post'] : '',
-                            'instructions' => 'Dynamically alter the user arguments before database insert/update',
+                            'instructions' => __('Dynamically alter the user arguments before database insert/update', 'acfe'),
                             'required' => 0,
                             'conditional_logic' => 0,
                             'wrapper' => array(
@@ -4529,11 +4529,11 @@ acf_add_local_field_group(array(
                         ),
                         array(
                             'key' => 'field_acfe_form_user_advanced_save',
-                            'label' => 'Add custom action on user save',
+                            'label' => __('Add custom action on user save', 'acfe'),
                             'name' => 'acfe_form_user_advanced_save',
                             'type' => 'acfe_dynamic_message',
                             'value' => isset($_REQUEST['post']) ? $_REQUEST['post'] : '',
-                            'instructions' => 'This action allows you to hook in before or after the meta data have been saved',
+                            'instructions' => __('This action allows you to hook in before or after the meta data have been saved', 'acfe'),
                             'required' => 0,
                             'conditional_logic' => 0,
                             'wrapper' => array(
@@ -4549,13 +4549,13 @@ acf_add_local_field_group(array(
 				),
                 
             ),
-            'button_label' => 'Add action',
+            'button_label' => __('Add action', 'acfe'),
             'min' => '',
             'max' => '',
         ),
         array(
             'key' => 'field_acfe_form_tab_advanced',
-            'label' => 'Advanced',
+            'label' => __('Advanced', 'acfe'),
             'name' => '',
             'type' => 'tab',
             'instructions' => '',
@@ -4572,10 +4572,10 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_post_field_groups',
-            'label' => 'Post field groups',
+            'label' => __('Post field groups', 'acfe'),
             'name' => 'acfe_form_post_field_groups',
             'type' => 'post_object',
-            'instructions' => 'Override rendered field groups with a specific post field groups.<br /><br/>Note: Make sure to set the related field groups in the "General" tab in order to map fields in the actions tab',
+            'instructions' => __('Override rendered field groups with a specific post field groups.<br /><br/>Note: Make sure to set the related field groups in the "General" tab in order to map fields in the actions tab', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -4591,10 +4591,10 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_honeypot',
-            'label' => 'Honeypot',
+            'label' => __('Honeypot', 'acfe'),
             'name' => 'acfe_form_honeypot',
             'type' => 'true_false',
-            'instructions' => 'Whether to include a hidden input field to capture non human form submission. Defaults to true.',
+            'instructions' => __('Whether to include a hidden input field to capture non human form submission. Defaults to true.', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -4614,7 +4614,7 @@ acf_add_local_field_group(array(
             'label' => 'Kses',
             'name' => 'acfe_form_kses',
             'type' => 'true_false',
-            'instructions' => 'Whether or not to sanitize all $_POST data with the wp_kses_post() function. Defaults to true.',
+            'instructions' => __('Whether or not to sanitize all $_POST data with the wp_kses_post() function. Defaults to true.', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -4631,11 +4631,11 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_uploader',
-            'label' => 'Uploader',
+            'label' => __('Uploader', 'acfe'),
             'name' => 'acfe_form_uploader',
             'type' => 'radio',
-            'instructions' => 'Whether to use the WP uploader or a basic input for image and file fields. Defaults to \'wp\' 
-    Choices of \'wp\' or \'basic\'.',
+            'instructions' => __('Whether to use the WP uploader or a basic input for image and file fields. Defaults to \'wp\' 
+    Choices of \'wp\' or \'basic\'.', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -4657,10 +4657,10 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_form_field_el',
-            'label' => 'Field element',
+            'label' => __('Field element', 'acfe'),
             'name' => 'acfe_form_form_field_el',
             'type' => 'radio',
-            'instructions' => 'Determines element used to wrap a field. Defaults to \'div\'',
+            'instructions' => __('Determines element used to wrap a field. Defaults to \'div\'', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(
@@ -4686,7 +4686,7 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_label_placement',
-            'label' => 'Label placement',
+            'label' => __('Label placement', 'acfe'),
             'name' => 'acfe_form_label_placement',
             'type' => 'radio',
             'instructions' => 'Determines where field labels are places in relation to fields. Defaults to \'top\'. <br />
@@ -4712,11 +4712,11 @@ acf_add_local_field_group(array(
         ),
         array(
             'key' => 'field_acfe_form_instruction_placement',
-            'label' => 'Instruction placement',
+            'label' => __('Instruction placement', 'acfe'),
             'name' => 'acfe_form_instruction_placement',
             'type' => 'radio',
-            'instructions' => 'Determines where field instructions are places in relation to fields. Defaults to \'label\'. <br />
-    Choices of \'label\' (Below labels) or \'field\' (Below fields)',
+            'instructions' => __('Determines where field instructions are places in relation to fields. Defaults to \'label\'. <br />
+    Choices of \'label\' (Below labels) or \'field\' (Below fields)', 'acfe'),
             'required' => 0,
             'conditional_logic' => 0,
             'wrapper' => array(

--- a/includes/modules/form/form-front.php
+++ b/includes/modules/form/form-front.php
@@ -39,7 +39,7 @@ class acfe_form_front{
         // Honeypot
 		if(!empty($acf['_validate_email'])){
 			
-			acf_add_validation_error('', __('Spam Detected', 'acf'));
+			acf_add_validation_error('', __('Spam Detected', 'acfe'));
 			
 		}
         
@@ -206,7 +206,7 @@ class acfe_form_front{
             'hide_unload'           => '',
             'errors_position'       => 'above',
             'errors_class'          => '',
-            'updated_message'		=> __('Post updated', 'acf'),
+            'updated_message'		=> __('Post updated', 'acfe'),
             'html_updated_message'  => '<div id="message" class="updated">%s</div>',
             'updated_hide_form'	    => false,
             'return'				=> '',

--- a/languages/acfe.pot
+++ b/languages/acfe.pot
@@ -1,0 +1,4272 @@
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Advanced Custom Fields: Extended\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-01-14 18:35+0000\n"
+"PO-Revision-Date: 2020-01-14 19:50+0000\n"
+"Last-Translator: Henrik Våglin <henrik.vaglin@gmail.com>\n"
+"Language-Team: \n"
+"Language: \n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Loco https://localise.biz/\n"
+"X-Loco-Version: 2.3.1; wp-5.3.2"
+
+#: includes/field-groups/field-groups.php:303
+msgid " is not registered locally"
+msgstr ""
+
+#: includes/field-groups/field-groups.php:295
+msgid " is registered locally"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:826
+msgid ""
+"(Array) (Optional) An array of post types to restrict this block type to."
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:804
+msgid ""
+"(Array) (Optional) An array of search terms to help user discover the block "
+"while searching.<br />One line for each keyword. ie:<br /><br />quote<br />"
+"mention<br />cite"
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:759
+msgid ""
+"(boolean)    Whether to load the option (values saved from this options page)"
+" when WordPress starts up.\n"
+"Defaults to false."
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:713
+msgid ""
+"(boolean) If set to true, this options page will redirect to the first child "
+"page (if a child page exists). \n"
+"If set to false, this parent page will appear alongside any child pages. "
+"Defaults to true"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1195
+msgid ""
+"(Callable) (Optional) A callback function that runs whenever your block is "
+"displayed (front-end and back-end) and enqueues scripts and/or styles."
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1110
+msgid ""
+"(Callable) (Optional) Instead of providing a render_template, a callback "
+"function name may be specified to output the block’s HTML."
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:736
+msgid ""
+"(int|string) The '$post_id' to save/load data to/from. Can be set to a "
+"numeric post ID (123), or a string ('user_2'). \n"
+"Defaults to 'options'."
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:643
+msgid ""
+"(int|string) The position in the menu order this menu should appear. "
+"Defaults to bottom of utility menu items.<br /><br />\n"
+"\n"
+"WARNING: if two menu items use the same position attribute, one of the items "
+"may be overwritten so that only one item displays!<br />\n"
+"Risk of conflict can be reduced by using decimal instead of integer values, "
+"e.g. '63.3' instead of 63 (must use quotes)."
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:957
+msgid ""
+"(String) (Optional) An icon property can be specified to make it easier to "
+"identify a block. These can be any of WordPress’ Dashicons, or a custom svg "
+"element."
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:876
+msgid ""
+"(String) (Optional) The default block alignment. Available settings are "
+"“left”, “center”, “right”, “wide” and “full”. Defaults to an empty string."
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:845
+msgid ""
+"(String) (Optional) The display mode for your block. Available settings are "
+"“auto”, “preview” and “edit”. Defaults to “auto”.<br /><br /> auto: Preview "
+"is shown by default but changes to edit form when block is selected.<br /> "
+"preview: Preview is always shown. Edit form appears in sidebar when block is "
+"selected.<br /> edit: Edit form is always shown.<br /><br /> Note. When in "
+"“preview” or “edit” modes, an icon will appear in the block toolbar to "
+"toggle between modes."
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1151
+msgid ""
+"(String) (Optional) The url to a .css file to be enqueued whenever your "
+"block is displayed (front-end and back-end)."
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1173
+msgid ""
+"(String) (Optional) The url to a .js file to be enqueued whenever your block "
+"is displayed (front-end and back-end)."
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:760
+msgid "(String) (Optional) This is a short description for your block."
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:734
+msgid ""
+"(String) A unique name that identifies the block (without namespace).<br />"
+"Note: A block name can only contain lowercase alphanumeric characters and "
+"dashes, and must begin with a letter."
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:782
+msgid ""
+"(String) Blocks are grouped into categories to help users browse and "
+"discover them. The core provided categories are [ common | formatting | "
+"layout | widgets | embed ]. Plugins and Themes can also register custom "
+"block categories."
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:549
+msgid "(string) Options page slug. Must be unique"
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:619
+msgid ""
+"(string) The capability required for this menu to be displayed to the user. "
+"Defaults to edit_posts.<br /><br />\n"
+"\n"
+"Read more about capability here: <a href=\"https://codex.wordpress."
+"org/Roles_and_Capabilities\">https://codex.wordpress."
+"org/Roles_and_Capabilities</a>"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:712
+msgid "(String) The display title for your block."
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:690
+msgid ""
+"(string) The icon class for this menu. Defaults to default WordPress gear."
+"<br /><br />\n"
+"Read more about dashicons here: <a href=\"https://developer.wordpress."
+"org/resource/dashicons/\">https://developer.wordpress."
+"org/resource/dashicons/</a>"
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:804
+msgid "(string) The message shown above the form on submit."
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1088
+msgid ""
+"(String) The path to a template file used to render the block HTML. This can "
+"either be a relative path to a file within the active theme or a full path "
+"to any file."
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:668
+msgid ""
+"(string) The slug of another WP admin page. if set, this will become a child "
+"page."
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:571
+msgid ""
+"(string) The title displayed in the wp-admin sidebar. Defaults to page_title"
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:782
+msgid "(string) The update button text."
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:593
+msgid ""
+"(string) The URL slug used to uniquely identify this options page. Defaults "
+"to a url friendly version of menu_title"
+msgstr ""
+
+#: includes/field-groups/field-groups.php:342
+msgid ".php will be created upon update"
+msgstr ""
+
+#: includes/admin/tools/dbt-import.php:198
+#, php-format
+msgid "1 block type imported"
+msgid_plural "%s block types imported"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/admin/tools/form-import.php:125
+#, php-format
+msgid "1 form imported"
+msgid_plural "%s forms imported"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/admin/tools/dop-import.php:185
+#, php-format
+msgid "1 options page imported"
+msgid_plural "%s options pages imported"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/admin/tools/dpt-import.php:219
+#, php-format
+msgid "1 post type imported"
+msgid_plural "%s post types imported"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/admin/tools/dt-import.php:217
+#, php-format
+msgid "1 taxonomy imported"
+msgid_plural "%s taxonomies imported"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/modules/dynamic-taxonomy.php:946
+msgid ""
+"A function name that will be called when the count of an associated "
+"$object_type, such as post, is updated"
+msgstr ""
+
+#: includes/modules/form/field-group.php:550
+msgid ""
+"A message displayed above the form after being redirected. Can also be empty "
+"for no message.<br /><br />You may use <code>{field:field_name}</code> or "
+"<code>{field:field_key}</code> template tags."
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:795
+msgid "A plural descriptive name for the taxonomy marked for translation"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:835
+msgid "A short descriptive summary of the post type"
+msgstr ""
+
+#: includes/admin/settings.php:52
+msgid ""
+"Absolute path to ACF plugin folder including trailing slash.<br />Defaults "
+"to plugin_dir_path"
+msgstr ""
+
+#: includes/admin/settings.php:88
+msgid ""
+"Absolute path to folder where json files will be created when field groups "
+"are saved.<br />Defaults to ‘acf-json’ folder within current theme"
+msgstr ""
+
+#: init.php:54
+msgid "ACF Extended requires Advanced Custom Fields PRO (minimum: 5.7.10)."
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:2013
+msgid ""
+"ACF Extended: Designates the ascending or descending order of the 'orderby' "
+"parameter in the admin list screen. Defaults to 'ASC'."
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1743 
+#: includes/modules/dynamic-post-type.php:2540
+msgid ""
+"ACF Extended: Designates the ascending or descending order of the 'orderby' "
+"parameter in the admin list screen. Defaults to 'DESC'."
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2178
+msgid ""
+"ACF Extended: Designates the ascending or descending order of the 'orderby' "
+"parameter in the archive page. Defaults to 'DESC'."
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2128
+msgid "ACF Extended: Number of posts to display in the archive page"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1693 
+#: includes/modules/dynamic-post-type.php:2490
+msgid "ACF Extended: Number of posts to display on the admin list screen"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1963
+msgid "ACF Extended: Number of terms to display on the admin list screen"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1717 
+#: includes/modules/dynamic-post-type.php:2514
+msgid ""
+"ACF Extended: Sort retrieved posts by parameter in the admin list screen. "
+"Defaults to 'date (post_date)'."
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2152
+msgid ""
+"ACF Extended: Sort retrieved posts by parameter in the archive page. "
+"Defaults to 'date (post_date)'."
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1987
+msgid ""
+"ACF Extended: Sort retrieved terms by parameter in the admin list screen. "
+"Accepts term fields 'name', 'slug', 'term_group', 'term_id', 'id', "
+"'description', 'parent', 'count' (for term taxonomy count), or 'none' to "
+"omit the ORDER BY clause"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2054 
+#: includes/modules/dynamic-post-type.php:2225
+msgid ""
+"ACF Extended: Which template file to load for the archive query. More "
+"informations on <a href=\"https://developer.wordpress."
+"org/themes/basics/template-hierarchy/\">Template hierarchy</a>"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1671
+msgid ""
+"ACF Extended: Which template file to load for the term query. More "
+"informations on <a href=\"https://developer.wordpress."
+"org/themes/basics/template-hierarchy/\">Template hierarchy</a>"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1048 
+#: includes/modules/form/field-group.php:2160 
+#: includes/modules/form/field-group.php:3025
+msgid "Action"
+msgstr ""
+
+#: includes/modules/form/field-group.php:737 
+#: includes/modules/form/field-group.php:1073 
+#: includes/modules/form/field-group.php:2185 
+#: includes/modules/form/field-group.php:3050
+msgid "Action alias"
+msgstr ""
+
+#: includes/modules/form/field-group.php:684
+msgid "Action name"
+msgstr ""
+
+#: includes/modules/form/admin.php:1322 
+#: includes/modules/form/field-group.php:629 
+#: includes/modules/form/field-group.php:646
+msgid "Actions"
+msgstr ""
+
+#: includes/modules/form/admin.php:159
+#, php-format
+msgid "Active <span class=\"count\">(%s)</span>"
+msgid_plural "Active <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/fields/field-taxonomies.php:228 
+#: includes/fields/field-post-statuses.php:228 
+#: includes/fields/field-post-types.php:228 
+#: includes/fields/field-user-roles.php:214 includes/fields/field-forms.php:228
+msgid "Add 'other' choice to allow for custom values"
+msgstr ""
+
+#: includes/modules/form/field-group.php:4552
+msgid "Add action"
+msgstr ""
+
+#: includes/modules/form/admin.php:559
+msgid "Add actions on form submission"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2469
+msgid "Add archive page to the post type administration."
+msgstr ""
+
+#: includes/modules/form/field-group.php:210
+msgid "Add class to all fields"
+msgstr ""
+
+#: includes/modules/form/field-group.php:516
+msgid "Add class to error message"
+msgstr ""
+
+#: includes/modules/form/field-group.php:2113
+msgid "Add custom action on post save"
+msgstr ""
+
+#: includes/modules/form/field-group.php:2978
+msgid "Add custom action on term save"
+msgstr ""
+
+#: includes/modules/form/field-group.php:4532
+msgid "Add custom action on user save"
+msgstr ""
+
+#: includes/field-groups/field-group.php:135
+msgid ""
+"Add custom meta data to the field group. Can be retrived using <code>"
+"acf_get_field_group()</code>"
+msgstr ""
+
+#: includes/modules/form/field-group.php:853
+msgid "Add file"
+msgstr ""
+
+#: includes/admin/views/html-options-list.php:4
+msgid "Add New"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1111
+msgid "Add new"
+msgstr ""
+
+#: includes/field-groups/field-group-category.php:27
+msgid "Add New category"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1215 
+#: includes/modules/dynamic-post-type.php:1133
+msgid "Add new item"
+msgstr ""
+
+#: includes/admin/options.php:458 includes/admin/views/html-options-edit.php:6
+msgid "Add Option"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1369
+msgid "Add or remove items"
+msgstr ""
+
+#: includes/field-groups/field-group.php:195
+msgid "Add personal note. Only visible to administrators"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:237
+msgid "Add Row"
+msgstr ""
+
+#: includes/fields-settings/settings.php:117
+msgid "Add settings"
+msgstr ""
+
+#: includes/fields-settings/validation.php:166
+msgid "Add validation"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1825 
+#: includes/modules/dynamic-post-type.php:2299
+msgid "Additional arguments"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1943 
+#: includes/modules/dynamic-post-type.php:2449
+msgid "Admin"
+msgstr ""
+
+#: includes/fields-settings/settings.php:135
+msgid "Administration"
+msgstr ""
+
+#: includes/modules/form/field-group.php:2064 
+#: includes/modules/form/field-group.php:2929 
+#: includes/modules/form/field-group.php:4483 
+#: includes/modules/form/field-group.php:4558
+msgid "Advanced"
+msgstr ""
+
+#: includes/admin/plugins.php:12
+msgid "Advanced Custom Fields"
+msgstr ""
+
+#. Name of the plugin
+msgid "Advanced Custom Fields: Extended"
+msgstr ""
+
+#: includes/fields/field-advanced-link.php:13
+msgid "Advanced Link"
+msgstr ""
+
+#: includes/field-groups/field-group.php:260
+msgid "Advanced Settings"
+msgstr ""
+
+#: includes/fields-settings/settings.php:112 
+#: includes/field-groups/field-group.php:120
+msgid "Advanced settings"
+msgstr ""
+
+#: includes/fields-settings/validation.php:161
+msgid "Advanced validation"
+msgstr ""
+
+#: includes/fields/field-button.php:83
+msgid "After HTML"
+msgstr ""
+
+#: includes/fields/field-button.php:92
+msgid "Ajax call"
+msgstr ""
+
+#: includes/fields/field-button.php:136
+msgid "Ajax instructions"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:873 
+#: includes/modules/dynamic-block-type.php:1233
+msgid "Align"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1255
+msgid "Align arguments"
+msgstr ""
+
+#: includes/locations/taxonomy-list.php:377 
+#: includes/fields/field-taxonomy-terms.php:476
+msgid "All"
+msgstr ""
+
+#: includes/fields/field-taxonomy-terms.php:150
+msgid "All "
+msgstr ""
+
+#: includes/field-groups/field-group-category.php:22
+msgid "All categories"
+msgstr ""
+
+#: includes/fields/field-forms.php:61
+msgid "All forms"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1127 
+#: includes/modules/dynamic-post-type.php:1331
+msgid "All items"
+msgstr ""
+
+#: includes/fields/field-post-statuses.php:61
+msgid "All post statuses"
+msgstr ""
+
+#: includes/fields/field-advanced-link.php:36 
+#: includes/fields/field-post-types.php:61
+msgid "All post types"
+msgstr ""
+
+#: includes/fields/field-advanced-link.php:49 
+#: includes/fields/field-taxonomies.php:61 
+#: includes/fields/field-taxonomy-terms.php:384
+msgid "All taxonomies"
+msgstr ""
+
+#: includes/fields/field-taxonomy-terms.php:464
+msgid "All terms"
+msgstr ""
+
+#: includes/fields/field-user-roles.php:60
+msgid "All user roles"
+msgstr ""
+
+#: includes/fields/field-post-object.php:16 
+#: includes/fields/field-taxonomies.php:319 
+#: includes/fields/field-post-statuses.php:319 
+#: includes/fields/field-post-types.php:319 
+#: includes/fields/field-user-roles.php:305 includes/fields/field-forms.php:319
+msgid "Allow 'custom' values to be added"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:180
+msgid "Allow copy/paste layouts functions"
+msgstr ""
+
+#: includes/fields/field-post-object.php:11 
+#: includes/fields/field-taxonomies.php:314 
+#: includes/fields/field-post-statuses.php:314 
+#: includes/fields/field-post-types.php:314 
+#: includes/fields/field-user-roles.php:300 includes/fields/field-forms.php:314
+msgid "Allow Custom"
+msgstr ""
+
+#: includes/fields/field-forms.php:53
+msgid "Allow Forms"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:166
+msgid "Allow layout title edition"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:101 
+#: includes/fields/field-taxonomy-terms.php:536 
+#: includes/fields/field-post-statuses.php:101 
+#: includes/fields/field-post-types.php:101 
+#: includes/fields/field-user-roles.php:87 includes/fields/field-forms.php:101
+msgid "Allow Null?"
+msgstr ""
+
+#: includes/admin/settings.php:342
+msgid "Allow PHP Sync"
+msgstr ""
+
+#: includes/fields/field-post-statuses.php:53
+msgid "Allow Post Status"
+msgstr ""
+
+#: includes/fields/field-post-types.php:53
+msgid "Allow Post Type"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:53 
+#: includes/fields/field-taxonomy-terms.php:376
+msgid "Allow Taxonomy"
+msgstr ""
+
+#: includes/fields/field-taxonomy-terms.php:455
+msgid "Allow Terms"
+msgstr ""
+
+#: includes/fields/field-user-roles.php:52
+msgid "Allow User Role"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1884
+msgid "Allowing permalinks to be prepended with front base"
+msgstr ""
+
+#: includes/admin/settings.php:202
+msgid ""
+"Allows ACF to enqueue and load the datetimepicker JS/CSS library.<br />"
+"Defaults to true"
+msgstr ""
+
+#: includes/admin/settings.php:178
+msgid ""
+"Allows ACF to enqueue and load the Google Maps API JS library.<br />Defaults "
+"to true"
+msgstr ""
+
+#: includes/admin/settings.php:184
+msgid ""
+"Allows ACF to enqueue and load the Select2 JS/CSS library.<br />Defaults to "
+"true"
+msgstr ""
+
+#: includes/admin/settings.php:196
+msgid ""
+"Allows ACF to enqueue and load the WP datepicker JS/CSS library.<br />"
+"Defaults to true"
+msgstr ""
+
+#: includes/admin/settings.php:214
+msgid ""
+"Allows ACF to remove the default WP custom fields metabox. Defaults to true"
+msgstr ""
+
+#: includes/admin/settings.php:142
+msgid ""
+"Allows ACF to translate field and field group settings using the __() "
+"function.<br />Defaults to true. Useful to override translation without "
+"modifying the textdomain"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:879
+msgid ""
+"An alias for calling add_post_type_support() directly. As of 3.5, boolean "
+"false can be passed as value instead of an array to prevent default (title "
+"and editor) behavior."
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1075
+msgid ""
+"An array of labels for this post type. By default, post labels are used for "
+"non-hierarchical post types and page labels for hierarchical ones.<br /><br "
+"/>\n"
+"Default: if empty, 'name' is set to value of 'label', and 'singular_name' is "
+"set to value of 'name'."
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1069
+msgid ""
+"An array of labels for this taxonomy. By default tag labels are used for non-"
+"hierarchical types and category labels for hierarchical ones.<br /><br />\n"
+"Default: if empty, name is set to label value, and singular_name is set to "
+"name value."
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:919
+msgid ""
+"An array of registered taxonomies like category or post_tag that will be "
+"used with this post type. This can be used in lieu of calling "
+"register_taxonomy_for_object_type() directly. Custom taxonomies still need "
+"to be registered with register_taxonomy()"
+msgstr ""
+
+#: includes/admin/settings.php:160
+msgid ""
+"An array of settings to translate when loading and exporting a field group."
+"<br />Defaults to array(’title’). Depreciated in v5.3.6 – please see "
+"acf/translate_field_group filter"
+msgstr ""
+
+#: includes/admin/settings.php:154
+msgid ""
+"An array of settings to translate when loading and exporting a field.<br />"
+"Defaults to array(’label’, ’instructions’). Depreciated in v5.3.6 – please "
+"see acf/translate_field filter"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1978
+msgid ""
+"An array of the capabilities for this post type. Specify capabilities like "
+"this:<br /><br />\n"
+"\n"
+"edit_post<br />\n"
+"read_post<br />\n"
+"delete_post<br />\n"
+"edit_posts<br />\n"
+"etc..."
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1628
+msgid ""
+"An array of the capabilities for this taxonomy:<br /><br />\n"
+"manage_terms<br />\n"
+"edit_terms<br />\n"
+"delete_terms<br />\n"
+"assign_terms"
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:232
+msgid "An error has occured."
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2631
+msgid ""
+"An optional custom controller to use instead of WP_REST_Posts_Controller. "
+"Must be a subclass of WP_REST_Controller"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:66 
+#: includes/fields/field-taxonomy-terms.php:483 
+#: includes/fields/field-post-statuses.php:66 
+#: includes/fields/field-post-types.php:66 
+#: includes/fields/field-user-roles.php:65
+msgid "Appearance"
+msgstr ""
+
+#: includes/fields/field-slug.php:67
+msgid "Appears after the input"
+msgstr ""
+
+#: includes/fields/field-slug.php:58
+msgid "Appears before the input"
+msgstr ""
+
+#: includes/fields/field-code-editor.php:58 includes/fields/field-slug.php:40
+msgid "Appears when creating a new post"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:127 
+#: includes/fields/field-taxonomy-terms.php:555 
+#: includes/fields/field-code-editor.php:66 
+#: includes/fields/field-code-editor.php:74 
+#: includes/fields/field-post-statuses.php:127 
+#: includes/fields/field-post-types.php:127 
+#: includes/fields/field-user-roles.php:113 
+#: includes/fields/field-forms.php:127 includes/fields/field-select.php:12 
+#: includes/fields/field-slug.php:49
+msgid "Appears within the input"
+msgstr ""
+
+#: includes/fields/field-slug.php:66
+msgid "Append"
+msgstr ""
+
+#: includes/locations/post-type-archive.php:41 
+#: includes/modules/dynamic-post-type.php:2034
+msgid "Archive"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2466
+msgid "Archive Page"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1353
+msgid "Archives"
+msgstr ""
+
+#: includes/admin/settings.php:94
+msgid ""
+"Array of absolutes paths to folders where field group json files can be read."
+"<br />Defaults to an array containing at index 0, the ‘acf-json’ folder "
+"within current theme"
+msgstr ""
+
+#: includes/admin/settings.php:124
+msgid ""
+"Array of keys used during the ‘Export to PHP’ feature to wrap strings within "
+"the __() function.<br />Defaults to array(’title’, ’label’, ’instructions’). "
+"Depreciated in v5.3.4 – please see l10n_field and l10n_field_group"
+msgstr ""
+
+#: includes/modules/form/field-group.php:836
+msgid "Attachments"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1375
+msgid "Attributes"
+msgstr ""
+
+#: includes/modules/author.php:85
+msgid "Author"
+msgstr ""
+
+#: includes/admin/settings.php:134
+msgid "Auto load"
+msgstr ""
+
+#: includes/field-groups/field-group.php:328
+msgid "Auto Sync"
+msgstr ""
+
+#: includes/admin/options.class.php:200 includes/admin/options.php:430 
+#: includes/modules/dynamic-options-page.php:756
+msgid "Autoload"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1316 
+#: includes/modules/form/field-group.php:2414 
+#: includes/modules/form/field-group.php:3176 
+#: includes/modules/form/field-group.php:3589
+msgid "Available tag:"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1435
+msgid "Back to items"
+msgstr ""
+
+#: includes/fields/field-button.php:74
+msgid "Before HTML"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:17
+msgid "Better layouts button integration"
+msgstr ""
+
+#: includes/fields/field-repeater.php:17
+msgid "Better row button integration"
+msgstr ""
+
+#: includes/fields-settings/bidirectional.php:17
+msgid "Bidirectional"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:23 
+#: includes/modules/dynamic-block-type.php:24 
+#: includes/modules/dynamic-block-type.php:27
+msgid "Block Type"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:26 
+#: includes/modules/dynamic-block-type.php:28 
+#: includes/modules/dynamic-block-type.php:69 
+#: includes/modules/dynamic-block-type.php:69
+msgid "Block Types"
+msgstr ""
+
+#: includes/fields/field-button.php:13 includes/fields/field-button.php:48
+msgid "Button"
+msgstr ""
+
+#: includes/fields/field-button.php:55
+msgid "Button attributes"
+msgstr ""
+
+#: includes/fields/field-button.php:32 includes/fields/field-button.php:41
+msgid "Button value"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1003
+msgid "Can export"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1006
+msgid "Can this post type be exported"
+msgstr ""
+
+#: includes/modules/form/actions/user.php:529
+msgid "Cannot create a user with an empty login name."
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1625 
+#: includes/modules/dynamic-post-type.php:1975
+msgid "Capabilities"
+msgstr ""
+
+#: includes/admin/settings.php:110 includes/modules/dynamic-taxonomy.php:1608 
+#: includes/modules/dynamic-options-page.php:616 
+#: includes/modules/dynamic-post-type.php:1932
+msgid "Capability"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1949
+msgid "Capability type"
+msgstr ""
+
+#: includes/admin/settings.php:112
+msgid ""
+"Capability used for ACF post types and if the current user can see the ACF "
+"menu item.<br />Defaults to ‘manage_options’."
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:292 
+#: includes/field-groups/field-group-category.php:41 
+#: includes/field-groups/field-group-category.php:41 
+#: includes/field-groups/field-group-category.php:63
+msgid "Categories"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:412 
+#: includes/modules/dynamic-block-type.php:390 
+#: includes/modules/dynamic-block-type.php:779
+msgid "Category"
+msgstr ""
+
+#: includes/field-groups/field-group-category.php:29
+msgid "category"
+msgstr ""
+
+#: includes/field-groups/field-group-category.php:19 
+#: includes/field-groups/field-group-category.php:20
+msgctxt "Category"
+msgid "Categories"
+msgstr ""
+
+#: includes/fields-settings/settings.php:115
+msgid "Change field settings based on location"
+msgstr ""
+
+#: includes/modules/form/field-group.php:2097
+msgid "Change post arguments"
+msgstr ""
+
+#: includes/modules/form/field-group.php:2962
+msgid "Change term arguments"
+msgstr ""
+
+#: includes/modules/form/field-group.php:4516
+msgid "Change user arguments"
+msgstr ""
+
+#: includes/modules/form/field-group.php:2081 
+#: includes/modules/form/field-group.php:2946 
+#: includes/modules/form/field-group.php:4500
+msgid "Change values source"
+msgstr ""
+
+#: includes/fields/field-code-editor.php:106 includes/fields/field-slug.php:75
+msgid "Character Limit"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:72 
+#: includes/fields/field-taxonomy-terms.php:489 
+#: includes/fields/field-post-statuses.php:72 
+#: includes/fields/field-post-types.php:72 includes/fields/field-forms.php:72
+msgid "Checkbox"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1391
+msgid "Choose from most used"
+msgstr ""
+
+#: includes/fields/field-button.php:42
+msgid "Choose the button type"
+msgstr ""
+
+#: includes/fields/field-image.php:26 includes/fields/field-file.php:26
+msgid "Choose the uploader type"
+msgstr ""
+
+#: includes/modules/form/field-group.php:489
+msgid "Choose where to display field errors"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1723
+msgid "Choose which ACF fields should be saved to this post"
+msgstr ""
+
+#: includes/modules/form/field-group.php:2663
+msgid "Choose which ACF fields should be saved to this term"
+msgstr ""
+
+#: includes/modules/form/field-group.php:4092
+msgid "Choose which ACF fields should be saved to this user"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1818 
+#: includes/modules/form/field-group.php:2758 
+#: includes/modules/form/field-group.php:4187
+msgid "Choose which ACF fields should have values filled"
+msgstr ""
+
+#: includes/fields/field-button.php:59
+msgid "class"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:56
+msgid "Click the \"Add Row\" button below to start creating your layout"
+msgstr ""
+
+#: includes/core/enqueue.php:94
+msgid "Close"
+msgstr ""
+
+#: includes/fields/field-code-editor.php:16
+msgid "Code Editor"
+msgstr ""
+
+#: includes/fields/field-textarea.php:11
+msgid "Code mode"
+msgstr ""
+
+#: includes/fields/field-column.php:13
+msgid "Column"
+msgstr ""
+
+#: includes/fields/field-column.php:30
+msgid "Columns"
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:72
+msgid "Compact"
+msgstr ""
+
+#: includes/fields/field-taxonomy-terms.php:673
+msgid "Connect selected terms to the post"
+msgstr ""
+
+#: includes/fields-settings/validation.php:237
+msgid "Contains"
+msgstr ""
+
+#: includes/modules/form/field-group.php:816
+msgid "Content"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:940
+msgid ""
+"Controls how the type is visible to authors (show_in_nav_menus, show_ui) and "
+"readers (exclude_from_search, publicly_queryable)"
+msgstr ""
+
+#: includes/admin/tools/dpt-export.php:202 
+#: includes/admin/tools/fg-local.php:223 
+#: includes/admin/tools/dbt-export.php:208 
+#: includes/admin/tools/dt-export.php:213
+msgid "Copied"
+msgstr ""
+
+#: includes/admin/tools/dpt-export.php:165 
+#: includes/admin/tools/fg-local.php:186 
+#: includes/admin/tools/dop-export.php:165 
+#: includes/admin/tools/dbt-export.php:171 
+#: includes/admin/tools/dt-export.php:176
+msgid "Copy to clipboard"
+msgstr ""
+
+#: includes/modules/form/admin.php:1403 
+#: includes/modules/form/field-group.php:1061
+msgid "Create post"
+msgstr ""
+
+#: includes/modules/form/admin.php:1426 
+#: includes/modules/form/field-group.php:2173
+msgid "Create term"
+msgstr ""
+
+#: includes/modules/form/admin.php:1449 
+#: includes/modules/form/field-group.php:3038
+msgid "Create user"
+msgstr ""
+
+#: includes/fields/field-code-editor.php:80
+msgid "CSS"
+msgstr ""
+
+#: includes/admin/settings.php:104
+msgid "Current language"
+msgstr ""
+
+#: includes/modules/form/admin.php:1573 includes/modules/form/admin.php:1645
+msgid "Current Post"
+msgstr ""
+
+#: includes/modules/form/admin.php:1768 includes/modules/form/admin.php:1842
+msgid "Current Post Author"
+msgstr ""
+
+#: includes/modules/form/admin.php:1945 includes/modules/form/admin.php:2004
+msgid "Current Term"
+msgstr ""
+
+#: includes/modules/form/admin.php:1764 includes/modules/form/admin.php:1841
+msgid "Current User"
+msgstr ""
+
+#: includes/modules/form/field-group.php:679
+msgid "Custom action"
+msgstr ""
+
+#: includes/modules/form/admin.php:1382
+msgid "Custom action: "
+msgstr ""
+
+#: includes/modules/form/field-group.php:1489
+msgid "Custom content"
+msgstr ""
+
+#: includes/fields/field-button.php:84
+msgid "Custom HTML after the button"
+msgstr ""
+
+#: includes/fields/field-button.php:75
+msgid "Custom HTML before the button"
+msgstr ""
+
+#: includes/field-groups/field-group.php:132
+msgid "Custom meta data"
+msgstr ""
+
+#: includes/fields-settings/settings.php:177
+msgid "Custom setting"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1282
+msgid "Custom title"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2330
+msgid ""
+"Customize the permalink structure slug. Defaults to the post type name value."
+" Should be translatable."
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:51
+msgid "Dark"
+msgstr ""
+
+#: includes/fields-settings/data.php:54 
+#: includes/field-groups/field-group.php:487 
+#: includes/field-groups/field-group.php:491
+msgid "Data"
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:514
+msgid "default"
+msgstr ""
+
+#: includes/admin/settings.php:98
+msgid "Default language"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:80 
+#: includes/fields/field-taxonomy-terms.php:496 
+#: includes/fields/field-code-editor.php:57 
+#: includes/fields/field-post-statuses.php:80 
+#: includes/fields/field-post-types.php:80 
+#: includes/fields/field-user-roles.php:79 includes/fields/field-forms.php:80 
+#: includes/fields/field-slug.php:39
+msgid "Default Value"
+msgstr ""
+
+#: includes/fields-settings/settings.php:174
+msgid "Default value"
+msgstr ""
+
+#: includes/fields/field-hidden.php:43
+msgid "Default value in the hidden input"
+msgstr ""
+
+#: includes/fields/field-column.php:56
+msgid ""
+"Define an endpoint for the previous tabs to stop. This will start a new "
+"group of columns."
+msgstr ""
+
+#: includes/admin/settings.php:208
+msgid ""
+"Defines the starting index used in all ‘loop’ and ‘row’ functions.<br />"
+"Defaults to 1 (1 is the first row), can be changed to 0 (0 is the first row)"
+msgstr ""
+
+#: includes/admin/settings.php:190
+msgid ""
+"Defines which version of Select2 library to enqueue. Either 3 or 4.<br />"
+"Defaults to 4 since ACF 5.6.0"
+msgstr ""
+
+#: includes/admin/options.class.php:180 includes/admin/options.php:478
+msgid "Delete"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1025
+msgid "Delete with user"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:836 
+#: includes/modules/dynamic-post-type.php:832 
+#: includes/modules/dynamic-block-type.php:757 
+#: includes/modules/form/field-group.php:2557 
+#: includes/modules/form/field-group.php:2638 
+#: includes/modules/form/field-group.php:2904 
+#: includes/modules/form/field-group.php:3929 
+#: includes/modules/form/field-group.php:4010 
+#: includes/modules/form/field-group.php:4433
+msgid "Description"
+msgstr ""
+
+#: includes/modules/form/field-group.php:4663
+msgid "Determines element used to wrap a field. Defaults to 'div'"
+msgstr ""
+
+#: includes/modules/form/field-group.php:4718
+msgid ""
+"Determines where field instructions are places in relation to fields. "
+"Defaults to 'label'. <br />\n"
+"    Choices of 'label' (Below labels) or 'field' (Below fields)"
+msgstr ""
+
+#: includes/admin/settings.php:334
+msgid "Dev mode"
+msgstr ""
+
+#: includes/admin/settings.php:56
+msgid "Directory"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:152
+msgid "Display a close button to collapse the layout"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:129
+msgid "Display a placeholder with a pencil icon, making edition easier"
+msgstr ""
+
+#: includes/modules/form/field-group.php:3723 
+#: includes/modules/form/field-group.php:3804 
+#: includes/modules/form/field-group.php:4383
+msgid "Display name"
+msgstr ""
+
+#: includes/field-groups/field-group.php:269
+msgid "Display title"
+msgstr ""
+
+#: includes/modules/form/field-group.php:469
+msgid "Do not prompt user on page refresh"
+msgstr ""
+
+#: includes/fields-settings/validation.php:238
+msgid "Doesn't contain"
+msgstr ""
+
+#: includes/fields-settings/validation.php:242
+msgid "Doesn't end with"
+msgstr ""
+
+#: includes/fields-settings/validation.php:240
+msgid "Doesn't start with"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:667
+msgid "Dynamic Block Type"
+msgstr ""
+
+#: includes/modules/form/field-group.php:8
+msgid "Dynamic Form"
+msgstr ""
+
+#: includes/fields/field-dynamic-message.php:13
+msgid "Dynamic Message"
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:500
+msgid "Dynamic Options Page"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:744
+msgid "Dynamic Post Type"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:751
+msgid "Dynamic Taxonomy"
+msgstr ""
+
+#: includes/modules/form/field-group.php:2101
+msgid "Dynamically alter the post arguments before database insert/update"
+msgstr ""
+
+#: includes/modules/form/field-group.php:2085
+msgid "Dynamically alter the post ID where meta values are loaded from"
+msgstr ""
+
+#: includes/modules/form/field-group.php:2966
+msgid "Dynamically alter the term arguments before database insert/update"
+msgstr ""
+
+#: includes/modules/form/field-group.php:2950
+msgid "Dynamically alter the term ID where meta values are loaded from"
+msgstr ""
+
+#: includes/modules/form/field-group.php:4520
+msgid "Dynamically alter the user arguments before database insert/update"
+msgstr ""
+
+#: includes/modules/form/field-group.php:4504
+msgid "Dynamically alter the user ID where meta values are loaded from"
+msgstr ""
+
+#: includes/fields/field-advanced-link.php:295 
+#: includes/fields/field-group.php:55 includes/fields/field-group.php:80 
+#: includes/fields/field-clone.php:51 includes/fields/field-clone.php:71 
+#: includes/admin/options.class.php:179 includes/admin/options.php:462 
+#: includes/modules/taxonomy.php:126
+msgid "Edit"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:29
+msgid "Edit Block Type"
+msgstr ""
+
+#: includes/field-groups/field-group-category.php:25
+msgid "Edit category"
+msgstr ""
+
+#: includes/admin/options.php:508
+msgid "Edit field group"
+msgstr ""
+
+#: includes/fields/field-group.php:33 includes/fields/field-clone.php:38
+msgid "Edit fields in a modal"
+msgstr ""
+
+#: includes/modules/form/admin.php:108
+msgid "Edit Form"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1149 
+#: includes/modules/dynamic-post-type.php:1155
+msgid "Edit item"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:194
+msgid "Edit layout content in a modal"
+msgstr ""
+
+#: includes/admin/options.php:463 includes/admin/views/html-options-edit.php:4
+msgid "Edit Option"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:23
+msgid "Edit Post Type"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:23
+msgid "Edit Taxonomy"
+msgstr ""
+
+#: includes/fields/field-group.php:30 includes/fields/field-clone.php:35
+msgid "Edition modal"
+msgstr ""
+
+#: includes/fields/field-group.php:50 includes/fields/field-clone.php:46
+msgid "Edition modal button"
+msgstr ""
+
+#: includes/fields/field-code-editor.php:73
+msgid "Editor mode"
+msgstr ""
+
+#: includes/modules/form/field-group.php:3104 
+#: includes/modules/form/field-group.php:3185 
+#: includes/modules/form/field-group.php:4233
+msgid "Email"
+msgstr ""
+
+#: includes/modules/form/admin.php:1390
+msgid "Email "
+msgstr ""
+
+#: includes/modules/form/field-group.php:713
+msgid "Email action"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:51
+msgid "Empty Message"
+msgstr ""
+
+#: includes/field-groups/field-group.php:125
+msgid "Enable advanced fields settings & validation"
+msgstr ""
+
+#: includes/fields/field-group.php:13 includes/fields/field-clone.php:13
+msgid "Enable better CSS integration: remove borders and padding"
+msgstr ""
+
+#: includes/admin/settings.php:82
+msgid "Enable/Disable json fields. Defaults to true"
+msgstr ""
+
+#: includes/admin/settings.php:76
+msgid "Enable/Disable local (PHP/json) fields. Defaults to true"
+msgstr ""
+
+#: includes/admin/settings.php:118
+msgid ""
+"Enable/Disable updates to appear in plugin list and show/hide the ACF "
+"updates admin page.<br />Defaults to true."
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2076
+msgid "Enables post type archives."
+msgstr ""
+
+#: includes/fields/field-column.php:55
+msgid "Endpoint"
+msgstr ""
+
+#: includes/fields-settings/validation.php:241
+msgid "Ends with"
+msgstr ""
+
+#. Description of the plugin
+msgid "Enhancement Suite which improves Advanced Custom Fields administration"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1129
+msgid "Enqueue"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1192
+msgid "Enqueue assets"
+msgstr ""
+
+#: includes/admin/settings.php:200
+msgid "Enqueue Date/timepicker"
+msgstr ""
+
+#: includes/admin/settings.php:194
+msgid "Enqueue Datepicker"
+msgstr ""
+
+#: includes/admin/settings.php:176
+msgid "Enqueue Google Maps"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1170
+msgid "Enqueue script"
+msgstr ""
+
+#: includes/admin/settings.php:182
+msgid "Enqueue Select2"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1148
+msgid "Enqueue style"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:81 
+#: includes/fields/field-taxonomy-terms.php:497 
+#: includes/fields/field-post-statuses.php:81 
+#: includes/fields/field-post-types.php:81 
+#: includes/fields/field-user-roles.php:80 includes/fields/field-forms.php:81
+msgid "Enter each default value on a new line"
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:114
+msgid ""
+"Enter the secret key. <a href=\"https://www.google.com/recaptcha/admin\" "
+"target=\"_blank\">reCaptcha API Admin</a>"
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:106
+msgid ""
+"Enter the site key. <a href=\"https://www.google.com/recaptcha/admin\" "
+"target=\"_blank\">reCaptcha API Admin</a>"
+msgstr ""
+
+#: includes/fields-settings/validation.php:366
+msgid "Error"
+msgstr ""
+
+#: includes/admin/tools/dt-import.php:60 
+#: includes/admin/tools/dpt-import.php:60 
+#: includes/admin/tools/dbt-import.php:60 
+#: includes/admin/tools/form-import.php:60
+msgid "Error uploading file. Please try again"
+msgstr ""
+
+#: includes/fields-settings/settings.php:143
+msgid "Everywhere"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:959
+msgid "Exclude from search"
+msgstr ""
+
+#: includes/admin/tools/dbt-export.php:21 
+#: includes/admin/tools/dbt-export.php:61
+msgid "Export Block Types"
+msgstr ""
+
+#: includes/admin/tools/dop-export.php:99 
+#: includes/admin/tools/form-export.php:99
+msgid "Export File"
+msgstr ""
+
+#: includes/admin/tools/form-export.php:21 
+#: includes/admin/tools/form-export.php:59
+msgid "Export Forms"
+msgstr ""
+
+#: includes/admin/tools/fg-local.php:13
+msgid "Export Local Field Groups"
+msgstr ""
+
+#: includes/admin/tools/dop-export.php:21 
+#: includes/admin/tools/dop-export.php:59
+msgid "Export Options Pages"
+msgstr ""
+
+#: includes/admin/tools/dpt-export.php:21 
+#: includes/admin/tools/dpt-export.php:59
+msgid "Export Post Types"
+msgstr ""
+
+#: includes/admin/tools/dt-export.php:21 includes/admin/tools/dt-export.php:59
+msgid "Export Taxonomies"
+msgstr ""
+
+#: includes/admin/settings.php:122
+msgid "Export textdomain"
+msgstr ""
+
+#: includes/admin/settings.php:128
+msgid "Export translate"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:111 
+#: includes/modules/form/admin.php:246
+msgid "Export:"
+msgstr ""
+
+#: includes/admin/tools/dbt-export.php:244
+#, php-format
+msgid "Exported 1 block type."
+msgid_plural "Exported %s block types."
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/admin/tools/fg-export.php:36
+#, php-format
+msgid "Exported 1 field group."
+msgid_plural "Exported %s field groups."
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/admin/tools/form-export.php:120
+#, php-format
+msgid "Exported 1 form."
+msgid_plural "Exported %s forms."
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/admin/tools/dop-export.php:238
+#, php-format
+msgid "Exported 1 option page."
+msgid_plural "Exported %s option pages."
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/admin/tools/dpt-export.php:238
+#, php-format
+msgid "Exported 1 post type."
+msgid_plural "Exported %s post types."
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/admin/tools/dt-export.php:249
+#, php-format
+msgid "Exported 1 taxonomy."
+msgid_plural "Exported %s taxonomies."
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/modules/form/field-group.php:311
+msgid "Extra HTML to add after the fields"
+msgstr ""
+
+#: includes/modules/form/field-group.php:271
+msgid "Extra HTML to add before the fields"
+msgstr ""
+
+#: includes/admin/settings.php:63 includes/admin/settings.php:69 
+#: includes/admin/settings.php:75 includes/admin/settings.php:81 
+#: includes/admin/settings.php:117 includes/admin/settings.php:123 
+#: includes/admin/settings.php:135 includes/admin/settings.php:141 
+#: includes/admin/settings.php:147 includes/admin/settings.php:177 
+#: includes/admin/settings.php:183 includes/admin/settings.php:195 
+#: includes/admin/settings.php:201 includes/admin/settings.php:213 
+#: includes/admin/settings.php:251 includes/admin/settings.php:257 
+#: includes/admin/settings.php:263 includes/admin/settings.php:269 
+#: includes/admin/settings.php:275 includes/admin/settings.php:281 
+#: includes/admin/settings.php:287 includes/admin/settings.php:335 
+#: includes/admin/settings.php:341 includes/admin/settings.php:347 
+#: includes/admin/settings.php:365 
+#: includes/modules/dynamic-options-page.php:729 
+#: includes/modules/dynamic-options-page.php:775
+msgid "False"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1441
+msgid "Featured image"
+msgstr ""
+
+#: includes/fields/field-image.php:41
+msgid "Featured thumbnail"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2387
+msgid "Feeds"
+msgstr ""
+
+#: includes/fields-settings/data.php:43
+msgid "Field data unavailable"
+msgstr ""
+
+#: includes/modules/form/field-group.php:4660
+msgid "Field element"
+msgstr ""
+
+#: includes/field-groups/field-group.php:114 includes/modules/dev.php:240
+msgid "Field group"
+msgstr ""
+
+#: includes/field-groups/field-group.php:181
+msgid "Field group data"
+msgstr ""
+
+#. Title
+#: includes/modules/dynamic-block-type.php:537 
+#: includes/modules/form/admin.php:1321 
+#: includes/modules/form/field-group.php:49
+msgid "Field groups"
+msgstr ""
+
+#: includes/admin/settings.php:304
+msgid "Field: reCaptcha secret key"
+msgstr ""
+
+#: includes/admin/settings.php:298
+msgid "Field: reCaptcha site key"
+msgstr ""
+
+#: includes/admin/settings.php:322
+msgid "Field: reCaptcha v2 size"
+msgstr ""
+
+#: includes/admin/settings.php:316
+msgid "Field: reCaptcha v2 theme"
+msgstr ""
+
+#: includes/admin/settings.php:328
+msgid "Field: reCaptcha v3 hide logo"
+msgstr ""
+
+#: includes/admin/settings.php:310
+msgid "Field: reCaptcha version"
+msgstr ""
+
+#. Title
+#: includes/field-groups/field-groups.php:71 
+#: includes/modules/form/admin.php:386
+msgid "Fields"
+msgstr ""
+
+#: includes/modules/form/field-group.php:207
+msgid "Fields class"
+msgstr ""
+
+#: includes/modules/form/field-group.php:513
+msgid "Fields errors class"
+msgstr ""
+
+#: includes/modules/form/field-group.php:486
+msgid "Fields errors position"
+msgstr ""
+
+#: includes/modules/form/field-group.php:730
+msgid ""
+"Fields may be included using <code>{field:field_key}</code> or <code>{field:"
+"title}</code>.<br />\n"
+"    All fields may be included using <code>{fields}</code>."
+msgstr ""
+
+#: includes/modules/form/field-group.php:1815 
+#: includes/modules/form/field-group.php:2755 
+#: includes/modules/form/field-group.php:4184
+msgid "Fields Values"
+msgstr ""
+
+#: includes/modules/form/field-group.php:857
+msgid "File"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1764 
+#: includes/modules/form/field-group.php:2704 
+#: includes/modules/form/field-group.php:4133
+msgid "Fill inputs with values"
+msgstr ""
+
+#: includes/fields/field-advanced-link.php:28
+msgid "Filter by Post Type"
+msgstr ""
+
+#: includes/fields/field-advanced-link.php:41
+msgid "Filter by Taxonomy"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1551
+msgid "Filter items list"
+msgstr ""
+
+#: includes/modules/form/field-group.php:3414 
+#: includes/modules/form/field-group.php:3495 
+#: includes/modules/form/field-group.php:4308
+msgid "First name"
+msgstr ""
+
+#: includes/field-groups/field-groups.php:335
+msgid ""
+"Folder '/acfe-php' was not found in your theme.<br />You must create it to "
+"activate this setting"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:318
+msgid "Force layouts to be collapsed or opened"
+msgstr ""
+
+#: includes/modules/form/admin.php:106
+msgid "Form"
+msgstr ""
+
+#: includes/modules/form/field-group.php:94
+msgid "Form attributes"
+msgstr ""
+
+#: includes/modules/form/field-group.php:97
+msgid "Form class and id"
+msgstr ""
+
+#: includes/modules/form/field-group.php:74
+msgid "Form element"
+msgstr ""
+
+#: includes/fields/field-forms.php:93
+msgid "Form ID"
+msgstr ""
+
+#: includes/fields/field-forms.php:94 includes/modules/form/field-group.php:29
+msgid "Form name"
+msgstr ""
+
+#: includes/locations/taxonomy-list.php:367 includes/fields/field-forms.php:13 
+#: includes/modules/form/admin.php:102 includes/modules/form/admin.php:103 
+#: includes/modules/form/admin.php:105 includes/modules/form/admin.php:107 
+#: includes/modules/form/admin.php:144 includes/modules/form/admin.php:144
+msgid "Forms"
+msgstr ""
+
+#: includes/admin/settings.php:366
+msgid "Found Json Sync load folder"
+msgstr ""
+
+#: includes/admin/settings.php:348
+msgid "Found PHP Sync load folder"
+msgstr ""
+
+#: includes/admin/settings.php:354
+msgid "Found PHP Sync save folder"
+msgstr ""
+
+#: includes/modules/form/field-group.php:757
+msgid "From"
+msgstr ""
+
+#: includes/fields-settings/settings.php:136
+msgid "Front-end"
+msgstr ""
+
+#: includes/fields-settings/validation.php:205
+msgid "Function"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:775 
+#: includes/modules/dynamic-post-type.php:768 
+#: includes/modules/dynamic-block-type.php:690 
+#: includes/modules/form/field-group.php:12
+msgid "General"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:788
+msgid "General name for the post type, usually plural. Default is Posts/Pages"
+msgstr ""
+
+#: includes/admin/tools/dpt-export.php:100 
+#: includes/admin/tools/dop-export.php:100 
+#: includes/admin/tools/dbt-export.php:102
+msgid "Generate PHP"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1281
+msgid "Generated ID"
+msgstr ""
+
+#: includes/modules/form/admin.php:1569 includes/modules/form/admin.php:1760 
+#: includes/modules/form/admin.php:1941
+msgid "Generic"
+msgstr ""
+
+#: includes/admin/settings.php:164 includes/admin/settings.php:170
+msgid "Google API Key"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2073
+msgid "Has archive"
+msgstr ""
+
+#: includes/fields/field-hidden.php:13
+msgid "Hidden"
+msgstr ""
+
+#: includes/modules/form/field-group.php:466
+msgid "Hide confirmation on exit"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:28
+msgid "Hide Empty Message"
+msgstr ""
+
+#: includes/fields-settings/settings.php:172
+msgid "Hide field"
+msgstr ""
+
+#: includes/modules/form/field-group.php:587
+msgid "Hide form"
+msgstr ""
+
+#: includes/modules/form/field-group.php:590
+msgid "Hide form on successful submission"
+msgstr ""
+
+#: includes/modules/form/field-group.php:446
+msgid "Hide general error"
+msgstr ""
+
+#: includes/fields-settings/settings.php:173
+msgid "Hide label"
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:87
+msgid "Hide logo"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:31
+msgid "Hide the empty message box"
+msgstr ""
+
+#: includes/modules/form/field-group.php:449
+msgid ""
+"Hide the general error message: \"Validation failed. 1 field requires "
+"attention\""
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:88
+msgid "Hide the reCaptcha logo"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:858 
+#: includes/modules/dynamic-taxonomy.php:1911 
+#: includes/modules/dynamic-post-type.php:854
+msgid "Hierarchical"
+msgstr ""
+
+#: includes/modules/form/field-group.php:4594
+msgid "Honeypot"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:274 
+#: includes/fields/field-taxonomy-terms.php:639 
+#: includes/fields/field-post-statuses.php:274 
+#: includes/fields/field-post-types.php:274 
+#: includes/fields/field-user-roles.php:260 includes/fields/field-forms.php:274
+msgid "Horizontal"
+msgstr ""
+
+#: includes/fields/field-code-editor.php:98
+msgid ""
+"How many spaces a block (whatever that means in the edited language) should "
+"be indented"
+msgstr ""
+
+#: includes/modules/form/field-group.php:308
+msgid "HTML After render"
+msgstr ""
+
+#: includes/modules/form/field-group.php:268
+msgid "HTML Before render"
+msgstr ""
+
+#: includes/modules/form/field-group.php:287
+msgid "HTML Form render"
+msgstr ""
+
+#: includes/modules/form/field-group.php:405
+msgid "HTML used to render the submit button loading spinner."
+msgstr ""
+
+#: includes/modules/form/field-group.php:378
+msgid "HTML used to render the submit button."
+msgstr ""
+
+#: includes/modules/form/field-group.php:570
+#, php-format
+msgid ""
+"HTML used to render the updated message.<br /><br />\n"
+"    If used, you have to include the following code <code>%s</code> to print "
+"the actual 'Success message' above."
+msgstr ""
+
+#. Author URI of the plugin
+msgid "https://www.acf-extended.com"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:906 
+#: includes/modules/dynamic-block-type.php:954
+msgid "Icon"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:984
+msgid "Icon background"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1010
+msgid "Icon foreground"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1036
+msgid "Icon src"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:925
+msgid "Icon Type"
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:687
+msgid "Icon url"
+msgstr ""
+
+#: includes/admin/options.class.php:197
+msgid "ID"
+msgstr ""
+
+#: includes/fields/field-button.php:68
+msgid "id"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1861
+msgid ""
+"If an existing top level page such as 'tools.php' or 'edit.php?"
+"post_type=page', the post type will be placed as a sub menu of that"
+msgstr ""
+
+#: includes/fields-settings/validation.php:30
+msgid "If email exists - email_exists(value)"
+msgstr ""
+
+#: includes/fields-settings/validation.php:58
+msgid "If get user by email - get_user_by('email', value)"
+msgstr ""
+
+#: includes/fields-settings/validation.php:56
+msgid "If get user by id - get_user_by('id', value)"
+msgstr ""
+
+#: includes/fields-settings/validation.php:59
+msgid "If get user by login - get_user_by('login', value)"
+msgstr ""
+
+#: includes/fields-settings/validation.php:57
+msgid "If get user by slug - get_user_by('slug', value)"
+msgstr ""
+
+#: includes/fields-settings/validation.php:38
+msgid "If is email - is_email(value))"
+msgstr ""
+
+#: includes/fields-settings/validation.php:39
+msgid "If is user logged in - is_user_logged_in()"
+msgstr ""
+
+#: includes/fields-settings/validation.php:31
+msgid "If post type exists - post_type_exists(value)"
+msgstr ""
+
+#: includes/fields-settings/validation.php:43
+msgid "If sanitize email - sanitize_email(value)"
+msgstr ""
+
+#: includes/fields-settings/validation.php:44
+msgid "If sanitize file name - sanitize_file_name(value)"
+msgstr ""
+
+#: includes/fields-settings/validation.php:45
+msgid "If sanitize html class - sanitize_html_class(value)"
+msgstr ""
+
+#: includes/fields-settings/validation.php:46
+msgid "If sanitize key - sanitize_key(value)"
+msgstr ""
+
+#: includes/fields-settings/validation.php:47
+msgid "If sanitize meta - sanitize_meta(value)"
+msgstr ""
+
+#: includes/fields-settings/validation.php:48
+msgid "If sanitize mime type - sanitize_mime_type(value)"
+msgstr ""
+
+#: includes/fields-settings/validation.php:49
+msgid "If sanitize option - sanitize_option(value)"
+msgstr ""
+
+#: includes/fields-settings/validation.php:50
+msgid "If sanitize text field - sanitize_text_field(value)"
+msgstr ""
+
+#: includes/fields-settings/validation.php:51
+msgid "If sanitize title - sanitize_title(value)"
+msgstr ""
+
+#: includes/fields-settings/validation.php:52
+msgid "If sanitize user - sanitize_user(value)"
+msgstr ""
+
+#: includes/fields-settings/validation.php:32
+msgid "If taxonomy exists - taxonomy_exists(value)"
+msgstr ""
+
+#: includes/fields-settings/validation.php:33
+msgid "If term exists - term_exists(value)"
+msgstr ""
+
+#: includes/fields-settings/validation.php:34
+msgid "If username exists - username_exists(value)"
+msgstr ""
+
+#: includes/fields-settings/validation.php:25
+msgid "If value"
+msgstr ""
+
+#: includes/fields-settings/validation.php:26
+msgid "If value length - strlen(value)"
+msgstr ""
+
+#: includes/admin/tools/dbt-import.php:18 
+#: includes/admin/tools/dbt-import.php:26
+msgid "Import Block Types"
+msgstr ""
+
+#: includes/admin/tools/dt-import.php:43 
+#: includes/admin/tools/dpt-import.php:43 
+#: includes/admin/tools/dbt-import.php:43 
+#: includes/admin/tools/dop-import.php:43 
+#: includes/admin/tools/form-import.php:43
+msgid "Import File"
+msgstr ""
+
+#: includes/admin/tools/dt-import.php:72 
+#: includes/admin/tools/dpt-import.php:72 
+#: includes/admin/tools/dbt-import.php:72 
+#: includes/admin/tools/dop-import.php:72 
+#: includes/admin/tools/form-import.php:72
+msgid "Import file empty"
+msgstr ""
+
+#: includes/admin/tools/form-import.php:26
+msgid "Import Forms"
+msgstr ""
+
+#: includes/admin/tools/dop-import.php:18 
+#: includes/admin/tools/dop-import.php:26
+msgid "Import Options Pages"
+msgstr ""
+
+#: includes/admin/tools/dpt-import.php:18 
+#: includes/admin/tools/dpt-import.php:26
+msgid "Import Post Types"
+msgstr ""
+
+#: includes/admin/tools/dt-import.php:18 includes/admin/tools/dt-import.php:26
+msgid "Import Taxonomies"
+msgstr ""
+
+#: includes/admin/tools/fg-local.php:29
+#, php-format
+msgid "Imported 1 field group"
+msgid_plural "Imported %s field groups"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/modules/dynamic-taxonomy.php:839
+msgid "Include a description of the taxonomy"
+msgstr ""
+
+#: includes/admin/tools/dt-import.php:64 
+#: includes/admin/tools/dpt-import.php:64 
+#: includes/admin/tools/dbt-import.php:64 
+#: includes/admin/tools/form-import.php:64
+msgid "Incorrect file type"
+msgstr ""
+
+#: includes/fields/field-code-editor.php:97
+msgid "Indent Unit"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1397
+msgid "Insert into item"
+msgstr ""
+
+#: includes/modules/form/field-group.php:4715
+msgid "Instruction placement"
+msgstr ""
+
+#: includes/fields-settings/settings.php:176 
+#: includes/fields/field-advanced-link.php:89 
+#: includes/fields/field-dynamic-message.php:43 
+#: includes/modules/form/field-group.php:718
+msgid "Instructions"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:861
+msgid ""
+"Is this taxonomy hierarchical (have descendants) like categories or not "
+"hierarchical like tags"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1639
+msgid "Item published"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1661
+msgid "Item published privately"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1683
+msgid "Item reverted to draft"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1705
+msgid "Item scheduled"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1727
+msgid "Item updated"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1595
+msgid "Items list"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1573
+msgid "Items list navigation"
+msgstr ""
+
+#: includes/fields/field-code-editor.php:79
+msgid "JavaScript"
+msgstr ""
+
+#: includes/admin/settings.php:80 includes/modules/dynamic-block-type.php:484
+msgid "Json"
+msgstr ""
+
+#: includes/field-groups/field-group.php:282
+msgid "Json Desync"
+msgstr ""
+
+#: includes/admin/settings.php:92
+msgid "Json folder (load)"
+msgstr ""
+
+#: includes/admin/settings.php:86
+msgid "Json folder (save)"
+msgstr ""
+
+#: includes/field-groups/field-groups.php:47
+msgid "Json sync"
+msgstr ""
+
+#: includes/admin/settings.php:364
+msgid "Json: Found"
+msgstr ""
+
+#: includes/field-groups/field-group.php:144 
+#: includes/modules/form/admin.php:431
+msgid "Key"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:801
+msgid "Keywords"
+msgstr ""
+
+#: includes/admin/settings.php:140
+msgid "l10n"
+msgstr ""
+
+#: includes/admin/settings.php:152
+msgid "l10n Field"
+msgstr ""
+
+#: includes/admin/settings.php:158
+msgid "l10n Field group"
+msgstr ""
+
+#: includes/admin/settings.php:146
+msgid "l10n Textdomain"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:792 
+#: includes/modules/dynamic-post-type.php:785 
+#: includes/modules/form/admin.php:429
+msgid "Label"
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:516
+msgid "label"
+msgstr ""
+
+#: includes/modules/form/field-group.php:4689
+msgid "Label placement"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1049 
+#: includes/modules/dynamic-taxonomy.php:1066 
+#: includes/modules/dynamic-post-type.php:1055 
+#: includes/modules/dynamic-post-type.php:1072
+msgid "Labels"
+msgstr ""
+
+#: includes/admin/settings.php:106
+msgid ""
+"Language code of the current post’s language. Defaults to ”.<br />If WPML is "
+"active, ACF will default this to the WPML current language"
+msgstr ""
+
+#: includes/admin/settings.php:100
+msgid ""
+"Language code of the default language. Defaults to ”.<br />If WPML is active,"
+" ACF will default this to the WPML default language setting"
+msgstr ""
+
+#: includes/modules/form/field-group.php:3517 
+#: includes/modules/form/field-group.php:3598 
+#: includes/modules/form/field-group.php:4333
+msgid "Last name"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:833 
+#: includes/fields/field-taxonomies.php:267 
+#: includes/fields/field-taxonomy-terms.php:632 
+#: includes/fields/field-post-statuses.php:267 
+#: includes/fields/field-post-types.php:267 
+#: includes/fields/field-user-roles.php:253 includes/fields/field-forms.php:267
+msgid "Layout"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:191
+msgid "Layouts Modal: Edition"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:205
+msgid "Layouts Modal: Selection"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:149
+msgid "Layouts: Close Button"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:177
+msgid "Layouts: Copy/Paste"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:103
+msgid "Layouts: Dynamic Preview"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:315
+msgid "Layouts: Force State"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:126
+msgid "Layouts: Placeholder"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:338
+msgid "Layouts: Remove Collapse"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:89
+msgid "Layouts: Render"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:75
+msgid "Layouts: Thumbnails"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:163
+msgid "Layouts: Title Edition"
+msgstr ""
+
+#: includes/fields/field-code-editor.php:107 includes/fields/field-slug.php:76
+msgid "Leave blank for no limit"
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:515
+msgid "left"
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:50
+msgid "Light"
+msgstr ""
+
+#: includes/fields/field-advanced-link.php:246
+msgid "Link text"
+msgstr ""
+
+#: includes/field-groups/field-groups.php:39 
+#: includes/field-groups/field-groups.php:73 
+#: includes/modules/form/field-group.php:1744 
+#: includes/modules/form/field-group.php:2684 
+#: includes/modules/form/field-group.php:4113
+msgid "Load"
+msgstr ""
+
+#: includes/fields/field-taxonomy-terms.php:681
+msgid "Load Terms"
+msgstr ""
+
+#: includes/fields/field-taxonomy-terms.php:682
+msgid "Load value from posts terms"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1761 
+#: includes/modules/form/field-group.php:2701 
+#: includes/modules/form/field-group.php:4130
+msgid "Load Values"
+msgstr ""
+
+#: includes/field-groups/field-group.php:283
+msgid ""
+"Local json file is different from this version. If you manually synchronize "
+"it, you will lose your current field group settings"
+msgstr ""
+
+#: includes/fields-settings/validation.php:171 
+#: includes/fields-settings/settings.php:122
+msgid "Location"
+msgstr ""
+
+#: includes/field-groups/field-groups.php:36 
+#: includes/field-groups/field-groups.php:72
+msgid "Locations"
+msgstr ""
+
+#: includes/fields/field-image.php:44
+msgid "Make this image the featured thumbnail"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2003
+msgid "Map meta cap"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1847 
+#: includes/modules/form/field-group.php:2787 
+#: includes/modules/form/field-group.php:4216
+msgid "Mapping"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1459 
+#: includes/modules/dynamic-post-type.php:1751
+msgid "Menu"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1792
+msgid "Menu icon"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1105 
+#: includes/modules/dynamic-post-type.php:1529
+msgid "Menu name"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1768
+msgid "Menu position"
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:568
+msgid "Menu title"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:965 
+#: includes/modules/dynamic-taxonomy.php:996
+msgid "Meta box callback"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:236
+msgid "Modal Title"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:842 
+#: includes/modules/dynamic-block-type.php:1285
+msgid "Mode"
+msgstr ""
+
+#: includes/admin/settings.php:250
+msgid "Module: Author"
+msgstr ""
+
+#: includes/admin/settings.php:256
+msgid "Module: Dynamic Block Types"
+msgstr ""
+
+#: includes/admin/settings.php:262
+msgid "Module: Dynamic Forms"
+msgstr ""
+
+#: includes/admin/settings.php:280
+msgid "Module: Dynamic Options Pages"
+msgstr ""
+
+#: includes/admin/settings.php:268
+msgid "Module: Dynamic Post Types"
+msgstr ""
+
+#: includes/admin/settings.php:274
+msgid "Module: Dynamic Taxonomies"
+msgstr ""
+
+#: includes/admin/settings.php:286
+msgid "Module: Options"
+msgstr ""
+
+#: includes/admin/settings.php:292
+msgid "Module: Taxonomies Enhancements"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1307
+msgid "Multiple"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:418
+msgid "Multiple categories can be set using \"|\""
+msgstr ""
+
+#: includes/admin/options.class.php:198 includes/admin/options.php:308 
+#: includes/modules/dev.php:238 includes/modules/dynamic-taxonomy.php:468 
+#: includes/modules/dynamic-taxonomy.php:814 
+#: includes/modules/dynamic-options-page.php:546 
+#: includes/modules/dynamic-post-type.php:513 
+#: includes/modules/dynamic-post-type.php:810 
+#: includes/modules/dynamic-block-type.php:389 
+#: includes/modules/dynamic-block-type.php:731 
+#: includes/modules/form/admin.php:430 includes/modules/form/admin.php:1320 
+#: includes/modules/form/field-group.php:770 
+#: includes/modules/form/field-group.php:2239 
+#: includes/modules/form/field-group.php:2320 
+#: includes/modules/form/field-group.php:2804
+msgid "Name"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1617
+msgid "Name admin bar"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:30
+msgid "New Block Type"
+msgstr ""
+
+#: includes/field-groups/field-group-category.php:28
+msgid "New category name"
+msgstr ""
+
+#: includes/modules/form/admin.php:109
+msgid "New Form"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1177
+msgid "New item"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1237
+msgid "New item name"
+msgstr ""
+
+#: includes/fields/field-post-object.php:36
+msgid "New Post Arguments"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:24
+msgid "New Post Type"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:24
+msgid "New Taxonomy"
+msgstr ""
+
+#: includes/modules/form/actions/user.php:547
+msgid "Nicename may not be longer than 50 characters."
+msgstr ""
+
+#: includes/modules/form/field-group.php:3620 
+#: includes/modules/form/field-group.php:3701 
+#: includes/modules/form/field-group.php:4358
+msgid "Nickname"
+msgstr ""
+
+#: includes/admin/options.php:445
+msgid "No"
+msgstr ""
+
+#: includes/admin/tools/dbt-export.php:261
+msgid "No block types selected"
+msgstr ""
+
+#: includes/admin/tools/dbt-export.php:84
+msgid "No dynamic block type available."
+msgstr ""
+
+#: includes/admin/tools/form-export.php:82
+msgid "No dynamic form available."
+msgstr ""
+
+#: includes/admin/tools/dpt-export.php:82
+msgid "No dynamic post type available."
+msgstr ""
+
+#: includes/admin/tools/dt-export.php:82
+msgid "No dynamic taxonomy available."
+msgstr ""
+
+#: includes/admin/tools/fg-local.php:51
+msgid "No field group selected"
+msgstr ""
+
+#: includes/modules/form/admin.php:565
+msgid "No field groups are currently mapped"
+msgstr ""
+
+#: includes/admin/tools/dt-import.php:53 
+#: includes/admin/tools/dpt-import.php:53 
+#: includes/admin/tools/dbt-import.php:53 
+#: includes/admin/tools/dop-import.php:53 
+#: includes/admin/tools/form-import.php:53
+msgid "No file selected"
+msgstr ""
+
+#: includes/admin/tools/form-export.php:137
+msgid "No forms selected"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:645 
+#: includes/modules/form/admin.php:496 includes/modules/form/admin.php:652 
+#: includes/modules/form/admin.php:681
+msgid "no label"
+msgstr ""
+
+#: includes/admin/options.class.php:99
+msgid "No options avaliable."
+msgstr ""
+
+#: includes/admin/tools/dop-export.php:82
+msgid "No options page available."
+msgstr ""
+
+#: includes/admin/tools/dop-export.php:255
+msgid "No options page selected"
+msgstr ""
+
+#: includes/admin/tools/dpt-export.php:255
+msgid "No post types selected"
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:71
+msgid "Normal"
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:513
+msgid "normal"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1413 
+#: includes/modules/dynamic-post-type.php:1265
+msgid "Not found"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1287
+msgid "Not found in trash"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:74 
+#: includes/fields/field-taxonomy-terms.php:490 
+#: includes/fields/field-post-statuses.php:74 
+#: includes/fields/field-post-types.php:74 
+#: includes/fields/field-user-roles.php:73 includes/fields/field-forms.php:74
+msgctxt "noun"
+msgid "Select"
+msgstr ""
+
+#: includes/fields/field-advanced-link.php:260
+msgid "Open in an new window"
+msgstr ""
+
+#: includes/fields-settings/settings.php:206
+msgid "Operator / Value"
+msgstr ""
+
+#: includes/admin/options.class.php:18
+msgid "Option"
+msgstr ""
+
+#: includes/admin/options.php:577
+msgid "Option has been added"
+msgstr ""
+
+#: includes/admin/options.php:161
+msgid "Option has been deleted"
+msgstr ""
+
+#: includes/admin/options.php:566
+msgid "Option has been updated"
+msgstr ""
+
+#: includes/admin/options.class.php:19 includes/admin/options.php:25 
+#: includes/admin/options.php:26
+msgid "Options"
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:748
+msgid "options"
+msgstr ""
+
+#: includes/admin/options.php:197
+msgid "Options have been deleted"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1740 
+#: includes/modules/dynamic-taxonomy.php:2010 
+#: includes/modules/dynamic-post-type.php:2175 
+#: includes/modules/dynamic-post-type.php:2537
+msgid "Order"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1714 
+#: includes/modules/dynamic-taxonomy.php:1984 
+#: includes/modules/dynamic-post-type.php:2149 
+#: includes/modules/dynamic-post-type.php:2511
+msgid "Order by"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:223 
+#: includes/fields/field-post-statuses.php:223 
+#: includes/fields/field-post-types.php:223 
+#: includes/fields/field-user-roles.php:209 includes/fields/field-forms.php:223
+msgid "Other"
+msgstr ""
+
+#: includes/modules/form/field-group.php:4578
+msgid ""
+"Override rendered field groups with a specific post field groups.<br /><br/>"
+"Note: Make sure to set the related field groups in the \"General\" tab in "
+"order to map fields in the actions tab"
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:524
+msgid "Page title"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2417
+msgid "Pages"
+msgstr ""
+
+#: includes/modules/form/field-group.php:2503 
+#: includes/modules/form/field-group.php:2535 
+#: includes/modules/form/field-group.php:2879
+msgid "Parent"
+msgstr ""
+
+#: includes/field-groups/field-group-category.php:23
+msgid "Parent category"
+msgstr ""
+
+#: includes/field-groups/field-group-category.php:24
+msgid "Parent category:"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1259
+msgid "Parent item"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1281 
+#: includes/modules/dynamic-post-type.php:1309
+msgid "Parent item colon"
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:665
+msgid "Parent slug"
+msgstr ""
+
+#: includes/modules/form/field-group.php:3310 
+#: includes/modules/form/field-group.php:3392 
+#: includes/modules/form/field-group.php:4283
+msgid "Password"
+msgstr ""
+
+#: includes/admin/settings.php:50
+msgid "Path"
+msgstr ""
+
+#: includes/field-groups/field-group.php:341
+msgid "Permissions"
+msgstr ""
+
+#: includes/admin/settings.php:340 includes/modules/dynamic-block-type.php:483
+msgid "PHP"
+msgstr ""
+
+#: includes/fields/field-code-editor.php:81
+msgid "PHP (mixed)"
+msgstr ""
+
+#: includes/fields/field-code-editor.php:82
+msgid "PHP (plain)"
+msgstr ""
+
+#: includes/modules/form/admin.php:1205
+msgid "PHP Field Validation"
+msgstr ""
+
+#: includes/modules/form/admin.php:1152
+msgid "PHP Form Integration"
+msgstr ""
+
+#: includes/modules/form/admin.php:1301
+msgid "PHP Form Submit: Custom Action"
+msgstr ""
+
+#: includes/modules/form/admin.php:1253
+msgid "PHP Form Validation"
+msgstr ""
+
+#: includes/field-groups/field-groups.php:43
+msgid "PHP sync"
+msgstr ""
+
+#: includes/admin/settings.php:360
+msgid "PHP Sync Load path"
+msgstr ""
+
+#: includes/admin/settings.php:74
+msgid "PHP/Json"
+msgstr ""
+
+#: includes/admin/settings.php:346
+msgid "PHP: Found"
+msgstr ""
+
+#: includes/admin/settings.php:358
+msgid "PHP: Load"
+msgstr ""
+
+#: includes/admin/settings.php:352
+msgid "PHP: Save"
+msgstr ""
+
+#: includes/fields-settings/settings.php:175 
+#: includes/fields/field-code-editor.php:65
+msgid "Placeholder"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:126 
+#: includes/fields/field-taxonomy-terms.php:554 
+#: includes/fields/field-post-statuses.php:126 
+#: includes/fields/field-post-types.php:126 
+#: includes/fields/field-user-roles.php:112 
+#: includes/fields/field-forms.php:126 includes/fields/field-select.php:11 
+#: includes/fields/field-slug.php:48
+msgid "Placeholder Text"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1325
+msgid "Popular items"
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:640
+msgid "Position"
+msgstr ""
+
+#: includes/locations/post-type-archive.php:83 
+#: includes/locations/post-type-list.php:376 
+#: includes/fields/field-advanced-link.php:196 
+#: includes/fields/field-advanced-link.php:225 
+#: includes/modules/form/actions/post.php:317
+msgid "Post"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1026
+msgid "Post action"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1554 
+#: includes/modules/form/field-group.php:1586 
+#: includes/modules/form/field-group.php:1989
+msgid "Post author"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1451 
+#: includes/modules/form/field-group.php:1532 
+#: includes/modules/form/field-group.php:1964
+msgid "Post content"
+msgstr ""
+
+#: includes/modules/form/field-group.php:4575
+msgid "Post field groups"
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:733
+msgid "Post ID"
+msgstr ""
+
+#: includes/fields-settings/data.php:49
+msgid "Post object unavailable"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1608 
+#: includes/modules/form/field-group.php:1640 
+#: includes/modules/form/field-group.php:2014
+msgid "Post parent"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1347 
+#: includes/modules/form/field-group.php:1429 
+#: includes/modules/form/field-group.php:1939
+msgid "Post slug"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1185 
+#: includes/modules/form/field-group.php:1221 
+#: includes/modules/form/field-group.php:1889
+msgid "Post status"
+msgstr ""
+
+#: includes/fields/field-post-statuses.php:94
+msgid "Post status name"
+msgstr ""
+
+#: includes/fields/field-post-statuses.php:93
+msgid "Post status object"
+msgstr ""
+
+#: includes/fields/field-post-statuses.php:13
+msgid "Post statuses"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1662 
+#: includes/modules/form/field-group.php:1698 
+#: includes/modules/form/field-group.php:2039
+msgid "Post terms"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1243 
+#: includes/modules/form/field-group.php:1325 
+#: includes/modules/form/field-group.php:1914
+msgid "Post title"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:21
+msgid "Post Type"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1127 
+#: includes/modules/form/field-group.php:1163 
+#: includes/modules/form/field-group.php:1864
+msgid "Post type"
+msgstr ""
+
+#: includes/locations/post-type-list.php:378
+msgid "Post Type List"
+msgstr ""
+
+#: includes/fields/field-post-types.php:94
+msgid "Post type name"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:813
+msgid ""
+"Post type name. Max. 20 characters, cannot contain capital letters or spaces"
+msgstr ""
+
+#: includes/fields/field-post-types.php:93
+msgid "Post type object"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:469 
+#: includes/modules/dynamic-post-type.php:17 
+#: includes/modules/dynamic-post-type.php:18 
+#: includes/modules/dynamic-post-type.php:20 
+#: includes/modules/dynamic-post-type.php:22 
+#: includes/modules/dynamic-block-type.php:391
+msgid "Post Types"
+msgstr ""
+
+#: includes/fields/field-post-types.php:13 
+#: includes/modules/dynamic-taxonomy.php:880 
+#: includes/modules/dynamic-block-type.php:823
+msgid "Post types"
+msgstr ""
+
+#: includes/modules/form/field-group.php:559 
+#: includes/modules/form/form-front.php:209
+msgid "Post updated"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:515
+msgid "Posts"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1690 
+#: includes/modules/dynamic-post-type.php:2125 
+#: includes/modules/dynamic-post-type.php:2487
+msgid "Posts per page"
+msgstr ""
+
+#: includes/fields/field-slug.php:57
+msgid "Prepend"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:297 
+#: includes/fields/field-taxonomy-terms.php:655 
+#: includes/fields/field-post-statuses.php:297 
+#: includes/fields/field-post-types.php:297 
+#: includes/fields/field-user-roles.php:283 includes/fields/field-forms.php:297
+msgid "Prepend an extra checkbox to toggle all choices"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:968
+msgid ""
+"Provide a callback function name for the meta box display.<br /><br/>"
+"Defaults to the categories meta box for hierarchical taxonomies and the tags "
+"meta box for non-hierarchical taxonomies. No meta box is shown if set to "
+"false."
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:899 
+#: includes/modules/dynamic-post-type.php:937
+msgid "Public"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:921 
+#: includes/modules/dynamic-post-type.php:981
+msgid "Publicly queryable"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:73 
+#: includes/fields/field-post-statuses.php:73 
+#: includes/fields/field-post-types.php:73 
+#: includes/fields/field-user-roles.php:72 includes/fields/field-forms.php:73
+msgid "Radio Buttons"
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:11
+msgid "reCAPTCHA"
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:225
+msgid "reCaptcha has expired."
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:38
+msgid "reCaptcha V2"
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:39
+msgid "reCaptcha V3"
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:710
+msgid "Redirect"
+msgstr ""
+
+#: includes/modules/form/field-group.php:607
+msgid "Redirection"
+msgstr ""
+
+#: includes/fields/field-advanced-link.php:296
+msgid "Remove"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:341
+msgid "Remove collapse action"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1485
+msgid "Remove featured image"
+msgstr ""
+
+#: includes/admin/settings.php:212
+msgid "Remove WP meta box"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:447 
+#: includes/modules/dynamic-block-type.php:392 
+#: includes/modules/dynamic-block-type.php:1066
+msgid "Render"
+msgstr ""
+
+#: includes/modules/form/field-group.php:52
+msgid "Render & map fields of the following field groups"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1085
+msgid "Render template"
+msgstr ""
+
+#: includes/field-groups/field-group.php:270
+msgid "Render this title on edit post screen"
+msgstr ""
+
+#: includes/modules/form/field-group.php:290
+msgid ""
+"Render your own customized HTML. This will override the native field groups "
+"render.<br /><br />\n"
+"    Field groups may be included using <code>{field_group:group_key}</code>"
+"<br/><code>{field_group:Group title}</code><br/><br/>\n"
+"    Fields may be included using <code>{field:field_key}</code><br/><code>"
+"{field:field_name}</code>"
+msgstr ""
+
+#: includes/fields-settings/settings.php:171
+msgid "Required"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:2040 
+#: includes/modules/dynamic-post-type.php:2567
+msgid "REST"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:2104
+msgid "REST API Controller class name"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:2079 
+#: includes/modules/dynamic-post-type.php:2606
+msgid "Rest base"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:2101 
+#: includes/modules/dynamic-post-type.php:2628
+msgid "Rest controller class"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:88 
+#: includes/fields/field-taxonomy-terms.php:504 
+#: includes/fields/field-post-statuses.php:88 
+#: includes/fields/field-post-types.php:88 includes/fields/field-forms.php:88
+msgid "Return Value"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1770 
+#: includes/modules/dynamic-post-type.php:2244
+msgid "Rewrite"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1792 
+#: includes/modules/dynamic-taxonomy.php:1822 
+#: includes/modules/dynamic-post-type.php:2266 
+#: includes/modules/dynamic-post-type.php:2296
+msgid "Rewrite Arguments"
+msgstr ""
+
+#: includes/modules/form/field-group.php:4032 
+#: includes/modules/form/field-group.php:4067 
+#: includes/modules/form/field-group.php:4458
+msgid "Role"
+msgstr ""
+
+#: includes/admin/settings.php:206
+msgid "Row index offset"
+msgstr ""
+
+#: includes/fields/field-code-editor.php:114
+msgid "Rows"
+msgstr ""
+
+#: includes/fields-settings/validation.php:195
+msgid "Rules"
+msgstr ""
+
+#: includes/admin/settings.php:70
+msgid ""
+"Runs the function stripslashes on all $_POST data. Some servers / WP instals "
+"may require this extra functioanlity. Defaults to false"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1031 
+#: includes/modules/form/field-group.php:2143 
+#: includes/modules/form/field-group.php:3008
+msgid "Save"
+msgstr ""
+
+#: includes/fields/field-post-object.php:26
+msgid "Save 'custom' values as new post"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:339 
+#: includes/fields/field-post-statuses.php:339 
+#: includes/fields/field-post-types.php:339 
+#: includes/fields/field-user-roles.php:325 includes/fields/field-forms.php:339
+msgid "Save 'custom' values to the field's choices"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:248 
+#: includes/fields/field-post-statuses.php:248 
+#: includes/fields/field-post-types.php:248 
+#: includes/fields/field-user-roles.php:234 includes/fields/field-forms.php:248
+msgid "Save 'other' values to the field's choices"
+msgstr ""
+
+#: includes/fields/field-post-object.php:21 
+#: includes/fields/field-taxonomies.php:334 
+#: includes/fields/field-post-statuses.php:334 
+#: includes/fields/field-post-types.php:334 
+#: includes/fields/field-user-roles.php:320 includes/fields/field-forms.php:334
+msgid "Save Custom"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1720 
+#: includes/modules/form/field-group.php:2660 
+#: includes/modules/form/field-group.php:4089
+msgid "Save Meta fields"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:243 
+#: includes/fields/field-post-statuses.php:243 
+#: includes/fields/field-post-types.php:243 
+#: includes/fields/field-user-roles.php:229 includes/fields/field-forms.php:243
+msgid "Save Other"
+msgstr ""
+
+#: includes/fields/field-taxonomy-terms.php:672
+msgid "Save Terms"
+msgstr ""
+
+#: includes/admin/views/html-options-list.php:23
+msgid "Search"
+msgstr ""
+
+#: includes/field-groups/field-group-category.php:21
+msgid "Search categories"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1303 
+#: includes/modules/dynamic-post-type.php:1243
+msgid "Search items"
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:113
+msgid "Secret key"
+msgstr ""
+
+#: includes/fields/field-group.php:10 includes/fields/field-clone.php:10
+msgid "Seemless Style"
+msgstr ""
+
+#: includes/admin/tools/dbt-export.php:70
+msgid "Select Block Types"
+msgstr ""
+
+#: includes/admin/tools/dt-import.php:32 
+#: includes/admin/tools/dpt-import.php:32 
+#: includes/admin/tools/dbt-import.php:32 
+#: includes/admin/tools/dop-import.php:32 
+#: includes/admin/tools/form-import.php:32
+msgid "Select File"
+msgstr ""
+
+#: includes/admin/tools/form-export.php:68
+msgid "Select Forms"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:208
+msgid "Select layouts in a modal"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:163 
+#: includes/fields/field-taxonomy-terms.php:591 
+#: includes/fields/field-post-statuses.php:163 
+#: includes/fields/field-post-types.php:163 
+#: includes/fields/field-user-roles.php:149 includes/fields/field-forms.php:163
+msgid "Select multiple values?"
+msgstr ""
+
+#: includes/admin/tools/dop-export.php:68
+msgid "Select Options Pages"
+msgstr ""
+
+#: includes/admin/tools/dpt-export.php:68
+msgid "Select Post Types"
+msgstr ""
+
+#: includes/admin/tools/dt-export.php:68
+msgid "Select Taxonomies"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:67 
+#: includes/fields/field-taxonomy-terms.php:484 
+#: includes/fields/field-post-statuses.php:67 
+#: includes/fields/field-post-types.php:67 
+#: includes/fields/field-user-roles.php:66
+msgid "Select the appearance of this field"
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:67
+msgid "Select the reCaptcha size"
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:46
+msgid "Select the reCaptcha theme"
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:34
+msgid "Select the reCaptcha version"
+msgstr ""
+
+#: includes/field-groups/field-group.php:345
+msgid ""
+"Select user roles that are allowed to view and edit this field group in post "
+"edition"
+msgstr ""
+
+#: includes/fields-settings/permissions.php:14
+msgid ""
+"Select user roles that are allowed to view and edit this field. If nothing "
+"is selected, then this field will be available to everyone."
+msgstr ""
+
+#: includes/admin/settings.php:188
+msgid "Select2 version"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1347
+msgid "Separate items with commas"
+msgstr ""
+
+#: includes/fields/field-button.php:33
+msgid "Set a default button value"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:78
+msgid ""
+"Set a thumbnail for each layouts. You must save the field group to apply "
+"this setting"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1463
+msgid "Set featured image"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:92
+msgid ""
+"Set template, style & javascript files for each layouts. This setting is "
+"mandatory in order to use <code style=\"font-size:11px;\">get_flexible()"
+"</code> function. You must save the field group to apply this setting"
+msgstr ""
+
+#: includes/fields-settings/bidirectional.php:20
+msgid "Set the field as bidirectional"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1258
+msgid ""
+"Set to an array of specific alignment names to customize the toolbar.<br />"
+"One line for each name. ie:<br /><br />left<br />right<br />full"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1773
+msgid ""
+"Set to false to prevent automatic URL rewriting a.k.a. \"pretty permalinks\"."
+" Pass an argument array to override default URL settings for permalinks"
+msgstr ""
+
+#: includes/admin/settings.php:136 includes/admin/settings.php:148
+msgid ""
+"Sets the text domain used when translating field and field group settings."
+"<br />Defaults to ”. Strings will not be translated if this setting is empty"
+msgstr ""
+
+#: includes/fields/field-code-editor.php:115
+msgid "Sets the textarea height"
+msgstr ""
+
+#: includes/fields-settings/settings.php:156
+msgid "Setting"
+msgstr ""
+
+#: includes/fields-settings/settings.php:181
+msgid "Setting name"
+msgstr ""
+
+#: includes/fields-settings/settings.php:146 
+#: includes/fields/field-flexible-content.php:375 
+#: includes/admin/settings.php:12 includes/admin/settings.php:12 
+#: includes/admin/settings.php:24 includes/admin/settings.php:29
+msgid "Settings"
+msgstr ""
+
+#: includes/modules/form/admin.php:1133 includes/modules/form/admin.php:1323
+msgid "Shortcode"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2390
+msgid ""
+"Should a feed permalink structure be built for this post type. Defaults to "
+"has_archive value."
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2360
+msgid ""
+"Should the permalink structure be prepended with the front base. (example: "
+"if your permalink structure is /blog/, then your links will be: false->"
+"/news/, true->/blog/news/). Defaults to true."
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2420
+msgid ""
+"Should the permalink structure provide for pagination. Defaults to true."
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1586
+msgid "Show admin column"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1910
+msgid "Show in admin bar"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1498 
+#: includes/modules/dynamic-post-type.php:1836
+msgid "Show in menu"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1858
+msgid "Show in menu (text)"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1520 
+#: includes/modules/dynamic-post-type.php:1888
+msgid "Show in nav menus"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1564
+msgid "Show in quick edit"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:2057 
+#: includes/modules/dynamic-post-type.php:2584
+msgid "Show in rest"
+msgstr ""
+
+#: includes/fields/field-code-editor.php:88
+msgid "Show Lines"
+msgstr ""
+
+#: includes/admin/settings.php:62
+msgid "Show menu"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1542
+msgid "Show tagcloud"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1476 
+#: includes/modules/dynamic-post-type.php:1814
+msgid "Show UI"
+msgstr ""
+
+#: includes/admin/settings.php:116
+msgid "Show updates"
+msgstr ""
+
+#: includes/admin/settings.php:64
+msgid "Show/hide ACF menu item. Defaults to true"
+msgstr ""
+
+#: includes/admin/settings.php:330
+msgid "Show/hide reCaptcha v3 logo"
+msgstr ""
+
+#: includes/admin/settings.php:336
+msgid "Show/hide the advanced WP post meta box. Defaults to false"
+msgstr ""
+
+#: includes/admin/settings.php:252
+msgid "Show/hide the Author module. Defaults to true"
+msgstr ""
+
+#: includes/admin/settings.php:258
+msgid "Show/hide the Block Types module. Defaults to true"
+msgstr ""
+
+#: includes/admin/settings.php:264
+msgid "Show/hide the Forms module. Defaults to true"
+msgstr ""
+
+#: includes/admin/settings.php:288
+msgid "Show/hide the Options module. Defaults to true"
+msgstr ""
+
+#: includes/admin/settings.php:282
+msgid "Show/hide the Options Pages module. Defaults to true"
+msgstr ""
+
+#: includes/admin/settings.php:270
+msgid "Show/hide the Post Types module. Defaults to true"
+msgstr ""
+
+#: includes/admin/settings.php:294
+msgid "Show/hide the Taxonomies enhancements module. Defaults to true"
+msgstr ""
+
+#: includes/admin/settings.php:276
+msgid "Show/hide the Taxonomies module. Defaults to true"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:928
+msgid ""
+"Simple: Specify a Dashicons class or SVG path<br /> Colors: Specify colors & "
+"Dashicons class"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1651 
+#: includes/modules/dynamic-post-type.php:2205
+msgid "Single"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1083 
+#: includes/modules/dynamic-post-type.php:1089
+msgid "Singular name"
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:105
+msgid "Site key"
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:66
+msgid "Size"
+msgstr ""
+
+#: includes/fields/field-slug.php:13 
+#: includes/modules/dynamic-taxonomy.php:1851 
+#: includes/modules/dynamic-post-type.php:2095 
+#: includes/modules/dynamic-post-type.php:2327 
+#: includes/modules/form/field-group.php:2342 
+#: includes/modules/form/field-group.php:2423 
+#: includes/modules/form/field-group.php:2829
+msgid "Slug"
+msgstr ""
+
+#: includes/modules/form/actions/user.php:539
+msgid "Sorry, that username already exists!"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1027
+msgid "Sort"
+msgstr ""
+
+#: includes/field-groups/field-groups.php:70
+msgid "Source"
+msgstr ""
+
+#: includes/modules/form/form-front.php:42
+msgid "Spam Detected"
+msgstr ""
+
+#: includes/admin/settings.php:166
+msgid ""
+"Specify a Google Maps API authentication key to prevent usage limits.<br />"
+"Defaults to ”"
+msgstr ""
+
+#: includes/admin/settings.php:172
+msgid ""
+"Specify a Google Maps API Client ID to prevent usage limits.<br />Not needed "
+"if using google_api_key. Defaults to ”"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:987
+msgid ""
+"Specifying a background color to appear with the icon e.g.: in the inserter."
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1013
+msgid ""
+"Specifying a color for the icon (optional: if not set, a readable color will "
+"be automatically defined)"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1039
+msgid "Specifying a dashicon for the block"
+msgstr ""
+
+#: includes/fields-settings/validation.php:239
+msgid "Starts with"
+msgstr ""
+
+#: includes/admin/settings.php:68
+msgid "Strip slashes"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:14 
+#: includes/fields/field-repeater.php:14
+msgid "Stylised Button"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:181 
+#: includes/fields/field-taxonomy-terms.php:518 
+#: includes/fields/field-post-statuses.php:181 
+#: includes/fields/field-post-types.php:181 
+#: includes/fields/field-user-roles.php:167 includes/fields/field-forms.php:181
+msgid "Stylised UI"
+msgstr ""
+
+#: includes/modules/form/field-group.php:796
+msgid "Subject"
+msgstr ""
+
+#: includes/modules/form/field-group.php:429
+msgid "Submission"
+msgstr ""
+
+#: includes/fields/field-button.php:16 includes/fields/field-button.php:36 
+#: includes/fields/field-button.php:49 includes/admin/options.php:457 
+#: includes/modules/form/field-group.php:367
+msgid "Submit"
+msgstr ""
+
+#: includes/modules/form/field-group.php:327 
+#: includes/modules/form/field-group.php:375
+msgid "Submit button"
+msgstr ""
+
+#: includes/modules/form/field-group.php:402
+msgid "Submit spinner"
+msgstr ""
+
+#: includes/modules/form/field-group.php:347
+msgid "Submit value"
+msgstr ""
+
+#: includes/modules/form/field-group.php:547
+msgid "Success message"
+msgstr ""
+
+#: includes/modules/form/field-group.php:567
+msgid "Success wrapper HTML"
+msgstr ""
+
+#: includes/core/helpers.php:374
+msgid "Super Admin"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:876 
+#: includes/modules/dynamic-block-type.php:1214
+msgid "Supports"
+msgstr ""
+
+#: includes/fields/field-textarea.php:14
+msgid ""
+"Switch font family to monospace and allow tab indent. For a more advanced "
+"code editor, please use the <code>Code Editor</code> field type"
+msgstr ""
+
+#: includes/fields/field-advanced-link.php:257 
+#: includes/modules/form/field-group.php:1093 
+#: includes/modules/form/field-group.php:2205 
+#: includes/modules/form/field-group.php:3070
+msgid "Target"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:13 
+#: includes/modules/dynamic-taxonomy.php:17 
+#: includes/modules/dynamic-taxonomy.php:18 
+#: includes/modules/dynamic-taxonomy.php:20 
+#: includes/modules/dynamic-taxonomy.php:22 
+#: includes/modules/dynamic-post-type.php:514 
+#: includes/modules/dynamic-post-type.php:916
+msgid "Taxonomies"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:21 
+#: includes/modules/form/field-group.php:2445 
+#: includes/modules/form/field-group.php:2481 
+#: includes/modules/form/field-group.php:2854
+msgid "Taxonomy"
+msgstr ""
+
+#: includes/locations/taxonomy-list.php:369
+msgid "Taxonomy List"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:94
+msgid "Taxonomy name"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:93
+msgid "Taxonomy object"
+msgstr ""
+
+#: includes/fields/field-taxonomy-terms.php:16
+msgid "Taxonomy Terms"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1668 
+#: includes/modules/dynamic-post-type.php:2051 
+#: includes/modules/dynamic-post-type.php:2222
+msgid "Template"
+msgstr ""
+
+#: includes/modules/form/field-group.php:2138
+msgid "Term action"
+msgstr ""
+
+#: includes/fields/field-taxonomy-terms.php:511
+msgid "Term ID"
+msgstr ""
+
+#: includes/fields/field-taxonomy-terms.php:510
+msgid "Term name"
+msgstr ""
+
+#: includes/fields/field-taxonomy-terms.php:509
+msgid "Term object"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:470
+msgid "Terms"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1960
+msgid "Terms per page"
+msgstr ""
+
+#: includes/fields/field-taxonomy-terms.php:470
+msgid "Terms_level"
+msgstr ""
+
+#: includes/fields/field-group.php:53 includes/fields/field-clone.php:49
+msgid "Text displayed in the edition modal button"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:54
+msgid "Text displayed when the flexible field is empty"
+msgstr ""
+
+#: includes/fields/field-code-editor.php:78
+msgid "Text/HTML"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2609
+msgid ""
+"The base slug that this post type will use when accessed using the REST API"
+msgstr ""
+
+#: includes/admin/settings.php:306
+msgid "The default reCaptcha secret key"
+msgstr ""
+
+#: includes/admin/settings.php:300
+msgid "The default reCaptcha site key"
+msgstr ""
+
+#: includes/admin/settings.php:324
+msgid "The default reCaptcha v2 size"
+msgstr ""
+
+#: includes/admin/settings.php:318
+msgid "The default reCaptcha v2 theme"
+msgstr ""
+
+#: includes/admin/settings.php:312
+msgid "The default reCaptcha version"
+msgstr ""
+
+#: includes/admin/tools/dbt-export.php:133
+msgid ""
+"The following code can be used to register a block type. Simply copy and "
+"paste the following code to your theme's functions.php file or include it "
+"within an external file."
+msgstr ""
+
+#: includes/admin/tools/fg-local.php:148
+msgid ""
+"The following code can be used to register a local version of the selected "
+"field group(s). A local field group can provide many benefits such as faster "
+"load times, version control & dynamic fields/settings. Simply copy and paste "
+"the following code to your theme's functions.php file or include it within "
+"an external file."
+msgstr ""
+
+#: includes/admin/tools/dop-export.php:131
+msgid ""
+"The following code can be used to register a option page. Simply copy and "
+"paste the following code to your theme's functions.php file or include it "
+"within an external file."
+msgstr ""
+
+#: includes/admin/tools/dpt-export.php:131
+msgid ""
+"The following code can be used to register a post type. Simply copy and "
+"paste the following code to your theme's functions.php file or include it "
+"within an external file."
+msgstr ""
+
+#: includes/admin/tools/dt-export.php:131
+msgid ""
+"The following code can be used to register a taxonomy. Simply copy and paste "
+"the following code to your theme's functions.php file or include it within "
+"an external file."
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:817
+msgid ""
+"The name of the taxonomy. Name should only contain lowercase letters and the "
+"underscore character, and not be more than 32 characters long (database "
+"structure restriction)"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1771
+msgid ""
+"The position in the menu order the post type should appear. show_in_menu "
+"must be true"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1952
+msgid ""
+"The string to use to build the read, edit, and delete capabilities.<br />\n"
+"May be passed as an array to allow for alternative plurals when using this "
+"argument as a base to construct the capabilities, like this:<br /><br />\n"
+"\n"
+"story<br />\n"
+"stories"
+msgstr ""
+
+#: includes/modules/form/field-group.php:350
+msgid "The text displayed on the submit button"
+msgstr ""
+
+#: includes/modules/form/field-group.php:32
+msgid "The unique form slug"
+msgstr ""
+
+#: includes/modules/form/field-group.php:610
+msgid ""
+"The URL to be redirected to after the form is submit. Defaults to the "
+"current URL.<br /><br />\n"
+"    A special placeholder <code>%post_url%</code> will be converted to "
+"post's permalink (handy if creating a new post)<br /><br />\n"
+"    A special placeholder <code>%post_id%</code> will be converted to post's "
+"ID (handy if creating a new post)<br />"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1795
+msgid ""
+"The url to the icon to be used for this menu or the name of the icon from "
+"the iconfont (<a href=\"https://developer.wordpress."
+"org/resource/dashicons/\" target=\"_blank\">Dashicons</a>)"
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:45
+msgid "Theme"
+msgstr ""
+
+#: includes/field-groups/field-groups-third-party.php:41
+msgid "Third party"
+msgstr ""
+
+#: includes/modules/form/field-group.php:2117 
+#: includes/modules/form/field-group.php:2982 
+#: includes/modules/form/field-group.php:4536
+msgid ""
+"This action allows you to hook in before or after the meta data have been "
+"saved"
+msgstr ""
+
+#: includes/modules/form/actions/custom.php:29
+msgid "This action name is not authorized"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:731
+msgid "This post type name already exists"
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1236
+msgid ""
+"This property adds block controls which allow the user to change the block’s "
+"alignment. Defaults to true. Set to false to hide the alignment toolbar. Set "
+"to an array of specific alignment names to customize the toolbar."
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1310
+msgid ""
+"This property allows the block to be added multiple times. Defaults to true."
+msgstr ""
+
+#: includes/modules/dynamic-block-type.php:1288
+msgid ""
+"This property allows the user to toggle between edit and preview modes via a "
+"button. Defaults to true."
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:693
+msgid "This taxonomy name already exists"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:674
+msgid "This taxonomy name is reserved"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:528
+msgid "Thumbnail"
+msgstr ""
+
+#: includes/field-groups/field-groups.php:69
+msgid "Title"
+msgstr ""
+
+#: includes/modules/form/field-group.php:777
+msgid "To"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:2082
+msgid "To change the base url of REST API route"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:296 
+#: includes/fields/field-taxonomy-terms.php:654 
+#: includes/fields/field-post-statuses.php:296 
+#: includes/fields/field-post-types.php:296 includes/fields/field-forms.php:296
+msgid "Toggle"
+msgstr ""
+
+#: includes/field-groups/field-group.php:575
+msgid "Tooltip"
+msgstr ""
+
+#: includes/fields/field-button.php:93
+msgid "Trigger ajax event on click"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2247
+msgid ""
+"Triggers the handling of rewrites for this post type. To prevent rewrites, "
+"set to false."
+msgstr ""
+
+#: includes/admin/settings.php:63 includes/admin/settings.php:69 
+#: includes/admin/settings.php:75 includes/admin/settings.php:81 
+#: includes/admin/settings.php:117 includes/admin/settings.php:123 
+#: includes/admin/settings.php:135 includes/admin/settings.php:141 
+#: includes/admin/settings.php:147 includes/admin/settings.php:177 
+#: includes/admin/settings.php:183 includes/admin/settings.php:195 
+#: includes/admin/settings.php:201 includes/admin/settings.php:213 
+#: includes/admin/settings.php:251 includes/admin/settings.php:257 
+#: includes/admin/settings.php:263 includes/admin/settings.php:269 
+#: includes/admin/settings.php:275 includes/admin/settings.php:281 
+#: includes/admin/settings.php:287 includes/admin/settings.php:335 
+#: includes/admin/settings.php:341 includes/admin/settings.php:347 
+#: includes/admin/settings.php:365 
+#: includes/modules/dynamic-options-page.php:728 
+#: includes/modules/dynamic-options-page.php:774
+msgid "True"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1523
+msgid "true makes this taxonomy available for selection in navigation menus"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1914
+msgid "True or false allow hierarchical urls"
+msgstr ""
+
+#: includes/fields/field-advanced-link.php:189 
+#: includes/modules/form/admin.php:432
+msgid "Type"
+msgstr ""
+
+#: includes/field-groups/field-groups.php:132 includes/modules/dev.php:254
+msgid "Unknown"
+msgstr ""
+
+#: includes/locations/post-type-list.php:337 
+#: includes/locations/taxonomy-list.php:328 includes/modules/taxonomy.php:136 
+#: includes/modules/dynamic-options-page.php:793
+msgid "Update"
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:779
+msgid "Update button"
+msgstr ""
+
+#: includes/field-groups/field-group-category.php:26
+msgid "Update category"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:943
+msgid "Update count callback"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1193
+msgid "Update item"
+msgstr ""
+
+#: includes/modules/form/admin.php:1411 
+#: includes/modules/form/field-group.php:1062
+msgid "Update post"
+msgstr ""
+
+#: includes/modules/form/admin.php:1434 
+#: includes/modules/form/field-group.php:2174
+msgid "Update term"
+msgstr ""
+
+#: includes/modules/form/admin.php:1457 
+#: includes/modules/form/field-group.php:3039
+msgid "Update user"
+msgstr ""
+
+#: includes/modules/dynamic-options-page.php:801
+msgid "Updated Message"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1419
+msgid "Uploaded to this item"
+msgstr ""
+
+#: includes/modules/form/field-group.php:4634
+msgid "Uploader"
+msgstr ""
+
+#: includes/fields/field-image.php:23 includes/fields/field-file.php:23
+msgid "Uploader type"
+msgstr ""
+
+#: includes/fields/field-advanced-link.php:195 
+#: includes/fields/field-advanced-link.php:204
+msgid "URL"
+msgstr ""
+
+#: includes/admin/settings.php:58
+msgid ""
+"URL to ACF plugin folder including trailing slash. Defaults to plugin_dir_url"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1795 
+#: includes/modules/dynamic-post-type.php:2269
+msgid "Use additional rewrite arguments"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:200 
+#: includes/fields/field-taxonomy-terms.php:609 
+#: includes/fields/field-post-statuses.php:200 
+#: includes/fields/field-post-types.php:200 
+#: includes/fields/field-user-roles.php:186 includes/fields/field-forms.php:200
+msgid "Use AJAX to lazy load choices?"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1507
+msgid "Use featured image"
+msgstr ""
+
+#: includes/fields/field-flexible-content.php:106
+msgid ""
+"Use layouts render settings to display a dynamic preview in the post "
+"administration"
+msgstr ""
+
+#: includes/modules/form/field-group.php:687
+msgid ""
+"Use the following hook:<br /><code>action('acfe/form/submit/my-custom-"
+"action', $form, $current_post_id)</code>"
+msgstr ""
+
+#: includes/admin/options.php:371
+msgid ""
+"Use this <a href=\"http://solutions.weblite.ca/php2json/\" target=\"_blank\">"
+"online tool</a> to decode/encode json."
+msgstr ""
+
+#: includes/admin/options.php:333
+msgid ""
+"Use this <a href=\"https://duzun.me/playground/serialize\" target=\"_blank\">"
+"online tool</a> to unserialize/seriliaze data."
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1854
+msgid ""
+"Used as pretty permalink text (i.e. /tag/) - defaults to $taxonomy "
+"(taxonomy's name slug)"
+msgstr ""
+
+#: includes/admin/settings.php:130
+msgid ""
+"Used during the ‘Export to PHP’ feature to wrap strings within the __() "
+"function.<br />Depreciated in v5.4.4 – please see l10n_textdomain"
+msgstr ""
+
+#: includes/modules/form/field-group.php:3003
+msgid "User action"
+msgstr ""
+
+#: includes/fields/field-user-roles.php:13
+msgid "User Roles"
+msgstr ""
+
+#: includes/modules/form/field-group.php:3207 
+#: includes/modules/form/field-group.php:3288 
+#: includes/modules/form/field-group.php:4258
+msgid "Username"
+msgstr ""
+
+#: includes/modules/form/actions/user.php:533
+msgid "Username may not be longer than 60 characters."
+msgstr ""
+
+#: includes/fields-settings/validation.php:164
+msgid "Validate value against rules"
+msgstr ""
+
+#: includes/fields-settings/settings.php:232 
+#: includes/fields/field-hidden.php:42 
+#: includes/field-groups/field-group.php:160 
+#: includes/admin/options.class.php:199 includes/admin/options.php:374 
+#: includes/modules/dev.php:239
+msgid "Value"
+msgstr ""
+
+#: includes/admin/options.php:406
+msgid "Value "
+msgstr ""
+
+#: includes/fields/field-slug.php:88
+#, php-format
+msgid "Value must not exceed %d characters"
+msgstr ""
+
+#: includes/modules/form/field-group.php:1781 
+#: includes/modules/form/field-group.php:2721 
+#: includes/modules/form/field-group.php:4150
+msgid "Values Source"
+msgstr ""
+
+#: includes/fields/field-taxonomy-terms.php:558 
+#: includes/fields/field-post-statuses.php:130 
+#: includes/fields/field-post-types.php:130 
+#: includes/fields/field-user-roles.php:116 
+#: includes/fields/field-forms.php:130 includes/fields/field-select.php:15
+msgctxt "verb"
+msgid "Select"
+msgstr ""
+
+#: includes/fields/field-recaptcha.php:33
+msgid "Version"
+msgstr ""
+
+#: includes/fields/field-taxonomies.php:273 
+#: includes/fields/field-taxonomy-terms.php:638 
+#: includes/fields/field-post-statuses.php:273 
+#: includes/fields/field-post-types.php:273 
+#: includes/fields/field-user-roles.php:259 includes/fields/field-forms.php:273
+msgid "Vertical"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1171 
+#: includes/modules/dynamic-post-type.php:1199
+msgid "View item"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1221
+msgid "View items"
+msgstr ""
+
+#: includes/field-groups/field-group.php:182
+msgid "View raw field group data, for development use"
+msgstr ""
+
+#: includes/modules/form/field-group.php:3826 
+#: includes/modules/form/field-group.php:3907 
+#: includes/modules/form/field-group.php:4408
+msgid "Website"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1839 
+#: includes/modules/dynamic-post-type.php:1913
+msgid "Where to show the post type in the admin menu. show_ui must be true"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1501
+msgid "Where to show the taxonomy in the admin menu. show_ui must be true"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:902
+msgid ""
+"Whether a taxonomy is intended for use publicly either via the admin "
+"interface or by front-end users"
+msgstr ""
+
+#: includes/modules/form/field-group.php:77
+msgid "Whether or not to create a <code>&lt;form&gt;</code> element"
+msgstr ""
+
+#: includes/modules/form/field-group.php:330
+msgid "Whether or not to create a form submit button. Defaults to true"
+msgstr ""
+
+#: includes/modules/form/field-group.php:4617
+msgid ""
+"Whether or not to sanitize all $_POST data with the wp_kses_post() function. "
+"Defaults to true."
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1891
+msgid "Whether post_type is available for selection in navigation menus"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:984
+msgid ""
+"Whether queries can be performed on the front end as part of parse_request()"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:857
+msgid ""
+"Whether the post type is hierarchical (e.g. page). Allows Parent to be "
+"specified. The 'supports' parameter should contain 'page-attributes' to show "
+"the parent select box on the editor page."
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:924
+msgid "Whether the taxonomy is publicly queryable"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1030
+msgid ""
+"Whether this taxonomy should remember the order in which terms are added to "
+"objects"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1589
+msgid ""
+"Whether to allow automatic creation of taxonomy columns on associated post-"
+"types table"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1545
+msgid "Whether to allow the Tag Cloud widget to use this taxonomy"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:1028
+msgid ""
+"Whether to delete posts of this type when deleting a user. If true, posts of "
+"this type belonging to the user will be moved to trash when then user is "
+"deleted.<br /><br />If false, posts of this type belonging to the user will "
+"not be trashed or deleted. If not set (the default), posts are trashed if "
+"the post type supports author. Otherwise posts are not trashed or deleted"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:962
+msgid ""
+"Whether to exclude posts with this post type from front end search results"
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2587
+msgid "Whether to expose this post type in the REST API"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1479 
+#: includes/modules/dynamic-post-type.php:1817
+msgid ""
+"Whether to generate a default UI for managing this post type in the admin"
+msgstr ""
+
+#: includes/modules/form/field-group.php:4597
+msgid ""
+"Whether to include a hidden input field to capture non human form submission."
+" Defaults to true."
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:2060
+msgid "Whether to include the taxonomy in the REST API"
+msgstr ""
+
+#: includes/fields/field-code-editor.php:89
+msgid "Whether to show line numbers to the left of the editor"
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1567
+msgid "Whether to show the taxonomy in the quick/bulk edit panel"
+msgstr ""
+
+#: includes/modules/form/field-group.php:4637
+msgid ""
+"Whether to use the WP uploader or a basic input for image and file fields. "
+"Defaults to 'wp' \n"
+"    Choices of 'wp' or 'basic'."
+msgstr ""
+
+#: includes/modules/dynamic-post-type.php:2098
+msgid "Will use post type name as archive slug by default."
+msgstr ""
+
+#: includes/modules/dynamic-taxonomy.php:1881 
+#: includes/modules/dynamic-post-type.php:2357
+msgid "With front"
+msgstr ""
+
+#: includes/fields/field-dynamic-message.php:28
+msgid "Write your own PHP/HTML content using the following hook:"
+msgstr ""
+
+#: includes/admin/options.php:446
+msgid "Yes"
+msgstr ""
+
+#: includes/modules/form/actions/term.php:390 
+#: includes/modules/form/actions/term.php:431 
+#: includes/modules/form/actions/term.php:491 
+#: includes/modules/form/actions/post.php:590 
+#: includes/modules/form/actions/post.php:655 
+#: includes/modules/form/actions/user.php:625 
+#: includes/modules/form/actions/user.php:666 
+#: includes/modules/form/actions/user.php:726
+msgid "You may use the following hooks:"
+msgstr ""


### PR DESCRIPTION
In my (master) branch I have gone over all files to make all strings able to translate (or as many as I were able to find, I might have missed a few). After that I have added an acfe.pot file in a new language folder, ready for translation. The plugin is full of features and so the translation became rather a daunting 800+ strings to translate, but I've seen plugins with more than that. 

I'm not much of a coder, so I've tried to stay in line with only touching the parts concerning making it translatable as namespace acfe. There were many strings that were using the acf or no namespace, as well as strings not using the regular __() hook. I added or changed all to using the acfe namespace, guessing it might have been slips or misses during other coding. 

Anyways, I'll hope you will find it useful to include in the master branch. If not I'd like to hear about it here anyways.

PS  I also posted a feature request about this, but then I felt like I'd give it a shot at fixing it myself (and mainly for myself). This is my first deep dive into hacking code to fix something and contribute it. Usually I just contribute translations to WP plugins I use. Now I can translate into my native Swedish. :-) DS