### PR TITLE
Add additional thumbnail filters

### DIFF
--- a/includes/fields/field-flexible-content.php
+++ b/includes/fields/field-flexible-content.php
@@ -44,7 +44,6 @@ function acfe_flexible_layout_preview($args = array()){
     $layout['acfe_flexible_thumbnail'] = apply_filters('acfe/flexible/thumbnail/key=' . $field['key'], $layout['acfe_flexible_thumbnail'], $field, $layout);
     
     // Layout Thumbnails
-    $layout['acfe_flexible_thumbnail'] = apply_filters('acfe/flexible/layout/thumbnail', $layout['acfe_flexible_thumbnail'], $field, $layout);
     $layout['acfe_flexible_thumbnail'] = apply_filters('acfe/flexible/layout/thumbnail/layout=' . $layout['name'], $layout['acfe_flexible_thumbnail'], $field, $layout);
     $layout['acfe_flexible_thumbnail'] = apply_filters('acfe/flexible/layout/thumbnail/name=' . $field['_name'] . '&layout=' . $layout['name'], $layout['acfe_flexible_thumbnail'], $field, $layout);
     $layout['acfe_flexible_thumbnail'] = apply_filters('acfe/flexible/layout/thumbnail/key=' . $field['key'] . '&layout=' . $layout['name'], $layout['acfe_flexible_thumbnail'], $field, $layout);
@@ -1211,7 +1210,6 @@ class acfe_field_flexible_content extends acf_field_flexible_content{
                 $thumbnail = apply_filters('acfe/flexible/thumbnail/name=' . $field['_name'],                                       $thumbnail, $field, $layout);
                 $thumbnail = apply_filters('acfe/flexible/thumbnail/key=' . $field['key'],                                          $thumbnail, $field, $layout);
         
-                $thumbnail = apply_filters('acfe/flexible/layout/thumbnail',                                                        $thumbnail, $field, $layout);
                 $thumbnail = apply_filters('acfe/flexible/layout/thumbnail/layout=' . $layout['name'],                              $thumbnail, $field, $layout);
                 $thumbnail = apply_filters('acfe/flexible/layout/thumbnail/name=' . $field['_name'] . '&layout=' . $layout['name'], $thumbnail, $field, $layout);
                 $thumbnail = apply_filters('acfe/flexible/layout/thumbnail/key=' . $field['key'] . '&layout=' . $layout['name'],    $thumbnail, $field, $layout);

--- a/includes/fields/field-flexible-content.php
+++ b/includes/fields/field-flexible-content.php
@@ -39,10 +39,12 @@ function acfe_flexible_layout_preview($args = array()){
         $layout['acfe_flexible_thumbnail'] = false;
     
     // Flexible Thumbnails
+    $layout['acfe_flexible_thumbnail'] = apply_filters('acfe/flexible/thumbnail', $layout['acfe_flexible_thumbnail'], $field, $layout);
     $layout['acfe_flexible_thumbnail'] = apply_filters('acfe/flexible/thumbnail/name=' . $field['_name'], $layout['acfe_flexible_thumbnail'], $field, $layout);
     $layout['acfe_flexible_thumbnail'] = apply_filters('acfe/flexible/thumbnail/key=' . $field['key'], $layout['acfe_flexible_thumbnail'], $field, $layout);
     
     // Layout Thumbnails
+    $layout['acfe_flexible_thumbnail'] = apply_filters('acfe/flexible/layout/thumbnail', $layout['acfe_flexible_thumbnail'], $field, $layout);
     $layout['acfe_flexible_thumbnail'] = apply_filters('acfe/flexible/layout/thumbnail/layout=' . $layout['name'], $layout['acfe_flexible_thumbnail'], $field, $layout);
     $layout['acfe_flexible_thumbnail'] = apply_filters('acfe/flexible/layout/thumbnail/name=' . $field['_name'] . '&layout=' . $layout['name'], $layout['acfe_flexible_thumbnail'], $field, $layout);
     $layout['acfe_flexible_thumbnail'] = apply_filters('acfe/flexible/layout/thumbnail/key=' . $field['key'] . '&layout=' . $layout['name'], $layout['acfe_flexible_thumbnail'], $field, $layout);
@@ -1205,9 +1207,11 @@ class acfe_field_flexible_content extends acf_field_flexible_content{
                 $thumbnail = $layout['acfe_flexible_thumbnail'] ? $layout['acfe_flexible_thumbnail'] : false;
                 
                 // Filters
+                $thumbnail = apply_filters('acfe/flexible/thumbnail',                                                               $thumbnail, $field, $layout);
                 $thumbnail = apply_filters('acfe/flexible/thumbnail/name=' . $field['_name'],                                       $thumbnail, $field, $layout);
                 $thumbnail = apply_filters('acfe/flexible/thumbnail/key=' . $field['key'],                                          $thumbnail, $field, $layout);
         
+                $thumbnail = apply_filters('acfe/flexible/layout/thumbnail',                                                        $thumbnail, $field, $layout);
                 $thumbnail = apply_filters('acfe/flexible/layout/thumbnail/layout=' . $layout['name'],                              $thumbnail, $field, $layout);
                 $thumbnail = apply_filters('acfe/flexible/layout/thumbnail/name=' . $field['_name'] . '&layout=' . $layout['name'], $thumbnail, $field, $layout);
                 $thumbnail = apply_filters('acfe/flexible/layout/thumbnail/key=' . $field['key'] . '&layout=' . $layout['name'],    $thumbnail, $field, $layout);


### PR DESCRIPTION
This PR adds a more generic filter for the thumbnails used in flexible layouts. Where the name/key is not known, this PR allows the filter to use the details of the layout to determine what should be done. In my particular case I can use this to dynamically link to a thumbnail image based on the layout name. For example:

```php
add_filter('acfe/flexible/layout/thumbnail', function ($thumbnail, $field, $layout){
	return get_layout_thumbnail_url("{$layout['name']}.jpg");
}, 10, 3);
```