### PR TITLE
Flexible content thumbnails can have remote images

### DIFF
--- a/includes/fields/field-flexible-content.php
+++ b/includes/fields/field-flexible-content.php
@@ -974,15 +974,13 @@ class acfe_field_flexible_content extends acf_field_flexible_content{
         // Thumbnail
         if($flexible['acfe_flexible_layouts_thumbnails']){
             
-            acf_render_field_wrap(array(
+	    acf_render_field_wrap(array(
                 'label'         => __('Thumbnail'),
                 'name'          => 'acfe_flexible_thumbnail',
-                'type'          => 'image',
+                'type'          => 'text',
                 'class'         => '',
                 'prefix'        => $prefix,
                 'value'         => $layout['acfe_flexible_thumbnail'],
-                'return_format' => 'array',
-                'preview_size'  => 'thumbnail',
                 'library'       => 'all',
             ), 'ul');
         


### PR DESCRIPTION
## :memo: Description
The flexible field became an awesome field after the ACF-Extended plugin but when it comes to creating a theme and making a theme home page builder using this field type, you will need to host the assets of the sections you have created with the flexible content field. then we need to have the option to set the URL of the image instead of uploading it to the website.



### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (a non-breaking change that enhancing the functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a migration update

