### PR TITLE
Update bidirectional.php

### DIFF
--- a/includes/fields-settings/bidirectional.php
+++ b/includes/fields-settings/bidirectional.php
@@ -671,9 +671,14 @@ class acfe_bidirectional{
             
             // add Value
             if($type === 'add'){
+                $unshift = apply_filters( 'acfe/bidirectional/prepend', false );
                 
                 if(!in_array($p_value, $r_values)){
-                    $r_values[] = $p_value;
+                    if($unshift){
+                        array_unshift($r_values, $p_value);
+                    }else{
+                        $r_values[] = $p_value;
+                    }    
                 }
                 
             }


### PR DESCRIPTION
Add a new filter  'acfe/bidirectional/prepend' that allows prepending instead of appending to target field array when adding related items.

This is useful for displaying lists of related posts where the freshest relationship should be at the top by default, but still allows editors to specify a custom sort.